### PR TITLE
Make WinToast implementation private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,8 @@ project(WinToast)
 set(CMAKE_CXX_STANDARD 14)
 
 add_library(WinToast STATIC
-        src/wintoastlib.cpp)
+        src/wintoastlib.cpp
+        src/wintoast_impl.cpp)
 target_include_directories(WinToast PRIVATE
         src)
 target_include_directories(WinToast PUBLIC

--- a/example/console-example/main.cpp
+++ b/example/console-example/main.cpp
@@ -1,5 +1,9 @@
-#include "wintoastlib.h"
+#include <Windows.h>
+
+#include <iostream>
 #include <string>     // std::string, std::stoi
+
+#include "wintoastlib.h"
 
 using namespace WinToastLib;
 

--- a/include/wintoastlib.h
+++ b/include/wintoastlib.h
@@ -21,40 +21,22 @@
 #ifndef WINTOASTLIB_H
 #define WINTOASTLIB_H
 
-#include <Windows.h>
-#include <sdkddkver.h>
-#include <WinUser.h>
-#include <ShObjIdl.h>
-#include <wrl/implements.h>
-#include <wrl/event.h>
-#include <windows.ui.notifications.h>
-#include <strsafe.h>
-#include <Psapi.h>
-#include <ShlObj.h>
-#include <roapi.h>
-#include <propvarutil.h>
-#include <functiondiscoverykeys.h>
-#include <iostream>
-#include <winstring.h>
-#include <cstring>
+#include <string>
 #include <vector>
-#include <map>
+#include <memory>
 
-using namespace Microsoft::WRL;
-using namespace ABI::Windows::Data::Xml::Dom;
-using namespace ABI::Windows::Foundation;
-using namespace ABI::Windows::UI::Notifications;
-using namespace Windows::Foundation;
-
+typedef signed __int64 INT64, *PINT64;
 
 namespace WinToastLib {
+
+    class WinToastImpl;
 
     class IWinToastHandler {
     public:
         enum class WinToastDismissalReason {
-            UserCanceled = ToastDismissalReason::ToastDismissalReason_UserCanceled,
-            ApplicationHidden = ToastDismissalReason::ToastDismissalReason_ApplicationHidden,
-            TimedOut = ToastDismissalReason::ToastDismissalReason_TimedOut
+            UserCanceled,
+            ApplicationHidden,
+            TimedOut,
         };
 
         virtual ~IWinToastHandler() = default;
@@ -83,14 +65,14 @@ namespace WinToastLib {
             FirstLine = 0, SecondLine, ThirdLine
         };
         enum class WinToastTemplateType {
-            ImageAndText01 = ToastTemplateType::ToastTemplateType_ToastImageAndText01,
-            ImageAndText02 = ToastTemplateType::ToastTemplateType_ToastImageAndText02,
-            ImageAndText03 = ToastTemplateType::ToastTemplateType_ToastImageAndText03,
-            ImageAndText04 = ToastTemplateType::ToastTemplateType_ToastImageAndText04,
-            Text01 = ToastTemplateType::ToastTemplateType_ToastText01,
-            Text02 = ToastTemplateType::ToastTemplateType_ToastText02,
-            Text03 = ToastTemplateType::ToastTemplateType_ToastText03,
-            Text04 = ToastTemplateType::ToastTemplateType_ToastText04,
+            ImageAndText01,
+            ImageAndText02,
+            ImageAndText03,
+            ImageAndText04,
+            Text01,
+            Text02,
+            Text03,
+            Text04,
         };
 
         enum class AudioSystemFile {
@@ -123,35 +105,35 @@ namespace WinToastLib {
         };
 
 
-        WinToastTemplate(_In_ WinToastTemplateType type = WinToastTemplateType::ImageAndText02);
+        WinToastTemplate(WinToastTemplateType type = WinToastTemplateType::ImageAndText02);
 
         ~WinToastTemplate();
 
-        void setFirstLine(_In_ const std::wstring &text);
+        void setFirstLine(const std::wstring &text);
 
-        void setSecondLine(_In_ const std::wstring &text);
+        void setSecondLine(const std::wstring &text);
 
-        void setThirdLine(_In_ const std::wstring &text);
+        void setThirdLine(const std::wstring &text);
 
-        void setTextField(_In_ const std::wstring &txt, _In_ TextField pos);
+        void setTextField(const std::wstring &txt, TextField pos);
 
-        void setAttributionText(_In_ const std::wstring &attributionText);
+        void setAttributionText(const std::wstring &attributionText);
 
-        void setImagePath(_In_ const std::wstring &imgPath);
+        void setImagePath(const std::wstring &imgPath);
 
-        void setAudioPath(_In_ WinToastTemplate::AudioSystemFile audio);
+        void setAudioPath(WinToastTemplate::AudioSystemFile audio);
 
-        void setAudioPath(_In_ const std::wstring &audioPath);
+        void setAudioPath(const std::wstring &audioPath);
 
-        void setAudioOption(_In_ WinToastTemplate::AudioOption audioOption);
+        void setAudioOption(WinToastTemplate::AudioOption audioOption);
 
-        void setDuration(_In_ Duration duration);
+        void setDuration(Duration duration);
 
-        void setExpiration(_In_ INT64 millisecondsFromNow);
+        void setExpiration(INT64 millisecondsFromNow);
 
-        void setScenario(_In_ Scenario scenario);
+        void setScenario(Scenario scenario);
 
-        void addAction(_In_ const std::wstring &label);
+        void addAction(const std::wstring &label);
 
         std::size_t textFieldsCount() const;
 
@@ -161,9 +143,9 @@ namespace WinToastLib {
 
         const std::vector<std::wstring> &textFields() const;
 
-        const std::wstring &textField(_In_ TextField pos) const;
+        const std::wstring &textField(TextField pos) const;
 
-        const std::wstring &actionLabel(_In_ std::size_t pos) const;
+        const std::wstring &actionLabel(std::size_t pos) const;
 
         const std::wstring &imagePath() const;
 
@@ -229,9 +211,7 @@ namespace WinToastLib {
             SHORTCUT_POLICY_REQUIRE_CREATE = 2,
         };
 
-        WinToast(void);
-
-        virtual ~WinToast();
+        virtual ~WinToast() = default;
 
         static WinToast *instance();
 
@@ -239,21 +219,21 @@ namespace WinToastLib {
 
         static bool isSupportingModernFeatures();
 
-        static std::wstring configureAUMI(_In_ const std::wstring &companyName,
-                                          _In_ const std::wstring &productName,
-                                          _In_ const std::wstring &subProduct = std::wstring(),
-                                          _In_ const std::wstring &versionInformation = std::wstring());
+        static std::wstring configureAUMI(const std::wstring &companyName,
+                                          const std::wstring &productName,
+                                          const std::wstring &subProduct = std::wstring(),
+                                          const std::wstring &versionInformation = std::wstring());
 
-        static const std::wstring &strerror(_In_ WinToastError error);
+        static const std::wstring &strerror(WinToastError error);
 
-        virtual bool initialize(_Out_opt_ WinToastError *error = nullptr);
+        virtual bool initialize(WinToastError *error = nullptr);
 
         virtual bool isInitialized() const;
 
-        virtual bool hideToast(_In_ INT64 id);
+        virtual bool hideToast(INT64 id);
 
-        virtual INT64 showToast(_In_ const WinToastTemplate &toast, _In_ IWinToastHandler *handler, _Out_opt_
-                                WinToastError *error = nullptr);
+        virtual INT64
+        showToast(const WinToastTemplate &toast, IWinToastHandler *handler, WinToastError *error = nullptr);
 
         virtual void clear();
 
@@ -263,43 +243,15 @@ namespace WinToastLib {
 
         const std::wstring &appUserModelId() const;
 
-        void setAppUserModelId(_In_ const std::wstring &aumi);
+        void setAppUserModelId(const std::wstring &aumi);
 
-        void setAppName(_In_ const std::wstring &appName);
+        void setAppName(const std::wstring &appName);
 
-        void setShortcutPolicy(_In_ ShortcutPolicy policy);
+        void setShortcutPolicy(ShortcutPolicy policy);
 
-    protected:
-        bool _isInitialized{false};
-        bool _hasCoInitialized{false};
-        ShortcutPolicy _shortcutPolicy{ShortcutPolicy::SHORTCUT_POLICY_REQUIRE_CREATE};
-        std::wstring _appName{};
-        std::wstring _aumi{};
-        std::map<INT64, ComPtr<IToastNotification>> _buffer{};
-
-        HRESULT validateShellLinkHelper(_Out_ bool &wasChanged);
-
-        HRESULT createShellLinkHelper();
-
-        HRESULT setImageFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &path);
-
-        HRESULT setAudioFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &path, _In_opt_
-                                    WinToastTemplate::AudioOption option = WinToastTemplate::AudioOption::Default);
-
-        HRESULT setTextFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &text, _In_ UINT32 pos);
-
-        HRESULT setAttributionTextFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &text);
-
-        HRESULT
-        addActionHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &action, _In_ const std::wstring &arguments);
-
-        HRESULT addDurationHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &duration);
-
-        HRESULT addScenarioHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &scenario);
-
-        ComPtr<IToastNotifier> notifier(_In_ bool *succeded) const;
-
-        void setError(_Out_opt_ WinToastError *error, _In_ WinToastError value);
+    private:
+        static WinToastImpl &winToastImpl;
     };
 }
+
 #endif // WINTOASTLIB_H

--- a/src/wintoast_impl.cpp
+++ b/src/wintoast_impl.cpp
@@ -1,0 +1,930 @@
+/* * Copyright (C) 2016-2019 Mohammed Boujemaoui <mohabouje@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "wintoast_impl.h"
+
+#include <wrl/event.h>
+#include <strsafe.h>
+#include <Psapi.h>
+#include <propvarutil.h>
+#include <functiondiscoverykeys.h>
+
+#include <iostream>
+#include <memory>
+#include <cassert>
+#include <array>
+
+#include "dll_importer.h"
+#include "wintoast_string_wrapper.h"
+#include "internal_date_time.h"
+
+#pragma comment(lib, "shlwapi")
+#pragma comment(lib, "user32")
+
+#ifdef NDEBUG
+#define DEBUG_MSG(str)
+#else
+#define DEBUG_MSG(str) std::wcout << str << std::endl
+#endif
+
+#define DEFAULT_SHELL_LINKS_PATH    L"\\Microsoft\\Windows\\Start Menu\\Programs\\"
+#define DEFAULT_LINK_FORMAT            L".lnk"
+#define STATUS_SUCCESS (0x00000000)
+
+using namespace WinToastLib;
+
+
+inline IWinToastHandler::WinToastDismissalReason getWinToastDismissalReason(const ToastDismissalReason reason) {
+    switch (reason) {
+        case ToastDismissalReason::ToastDismissalReason_UserCanceled:
+            return IWinToastHandler::WinToastDismissalReason::UserCanceled;
+        case ToastDismissalReason::ToastDismissalReason_ApplicationHidden:
+            return IWinToastHandler::WinToastDismissalReason::ApplicationHidden;
+        case ToastDismissalReason::ToastDismissalReason_TimedOut:
+        default:
+            return IWinToastHandler::WinToastDismissalReason::TimedOut;
+    }
+}
+
+inline ToastTemplateType getToastTemplateType(const WinToastTemplate::WinToastTemplateType type) {
+    switch (type) {
+        case WinToastTemplate::WinToastTemplateType::ImageAndText01:
+            return ToastTemplateType::ToastTemplateType_ToastImageAndText01;
+        case WinToastTemplate::WinToastTemplateType::ImageAndText02:
+            return ToastTemplateType::ToastTemplateType_ToastImageAndText02;
+        case WinToastTemplate::WinToastTemplateType::ImageAndText03:
+            return ToastTemplateType::ToastTemplateType_ToastImageAndText03;
+        case WinToastTemplate::WinToastTemplateType::ImageAndText04:
+            return ToastTemplateType::ToastTemplateType_ToastImageAndText04;
+        case WinToastTemplate::WinToastTemplateType::Text01:
+            return ToastTemplateType::ToastTemplateType_ToastText01;
+        case WinToastTemplate::WinToastTemplateType::Text02:
+            return ToastTemplateType::ToastTemplateType_ToastText02;
+        case WinToastTemplate::WinToastTemplateType::Text03:
+            return ToastTemplateType::ToastTemplateType_ToastText03;
+        case WinToastTemplate::WinToastTemplateType::Text04:
+        default:
+            return ToastTemplateType::ToastTemplateType_ToastText04;
+    }
+}
+
+// Quickstart: Handling toast activations from Win32 apps in Windows 10
+// https://blogs.msdn.microsoft.com/tiles_and_toasts/2015/10/16/quickstart-handling-toast-activations-from-win32-apps-in-windows-10/
+namespace Util {
+
+    typedef LONG NTSTATUS, *PNTSTATUS;
+
+    typedef NTSTATUS(WINAPI *RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
+
+    inline RTL_OSVERSIONINFOW getRealOSVersion() {
+        HMODULE hMod = ::GetModuleHandleW(L"ntdll.dll");
+        if (hMod) {
+            RtlGetVersionPtr fxPtr = (RtlGetVersionPtr) ::GetProcAddress(hMod, "RtlGetVersion");
+            if (fxPtr != nullptr) {
+                RTL_OSVERSIONINFOW rovi = {0};
+                rovi.dwOSVersionInfoSize = sizeof(rovi);
+                if (STATUS_SUCCESS == fxPtr(&rovi)) {
+                    return rovi;
+                }
+            }
+        }
+        RTL_OSVERSIONINFOW rovi = {0};
+        return rovi;
+    }
+
+    inline HRESULT defaultExecutablePath(_In_ WCHAR *path, _In_ DWORD nSize = MAX_PATH) {
+        DWORD written = GetModuleFileNameExW(GetCurrentProcess(), nullptr, path, nSize);
+        DEBUG_MSG("Default executable path: " << path);
+        return (written > 0) ? S_OK : E_FAIL;
+    }
+
+
+    inline HRESULT defaultShellLinksDirectory(_In_ WCHAR *path, _In_ DWORD nSize = MAX_PATH) {
+        DWORD written = GetEnvironmentVariableW(L"APPDATA", path, nSize);
+        HRESULT hr = written > 0 ? S_OK : E_INVALIDARG;
+        if (SUCCEEDED(hr)) {
+            errno_t result = wcscat_s(path, nSize, DEFAULT_SHELL_LINKS_PATH);
+            hr = (result == 0) ? S_OK : E_INVALIDARG;
+            DEBUG_MSG("Default shell link path: " << path);
+        }
+        return hr;
+    }
+
+    inline HRESULT defaultShellLinkPath(const std::wstring &appname, _In_ WCHAR *path, _In_ DWORD nSize = MAX_PATH) {
+        HRESULT hr = defaultShellLinksDirectory(path, nSize);
+        if (SUCCEEDED(hr)) {
+            const std::wstring appLink(appname + DEFAULT_LINK_FORMAT);
+            errno_t result = wcscat_s(path, nSize, appLink.c_str());
+            hr = (result == 0) ? S_OK : E_INVALIDARG;
+            DEBUG_MSG("Default shell link file path: " << path);
+        }
+        return hr;
+    }
+
+
+    inline PCWSTR AsString(ComPtr<IXmlDocument> &xmlDocument) {
+        HSTRING xml;
+        ComPtr<IXmlNodeSerializer> ser;
+        HRESULT hr = xmlDocument.As<IXmlNodeSerializer>(&ser);
+        hr = ser->GetXml(&xml);
+        if (SUCCEEDED(hr))
+            return DllImporter::WindowsGetStringRawBuffer(xml, nullptr);
+        return nullptr;
+    }
+
+    inline PCWSTR AsString(HSTRING hstring) {
+        return DllImporter::WindowsGetStringRawBuffer(hstring, nullptr);
+    }
+
+    inline HRESULT setNodeStringValue(const std::wstring &string, IXmlNode *node, IXmlDocument *xml) {
+        ComPtr<IXmlText> textNode;
+        HRESULT hr = xml->CreateTextNode(WinToastStringWrapper(string).Get(), &textNode);
+        if (SUCCEEDED(hr)) {
+            ComPtr<IXmlNode> stringNode;
+            hr = textNode.As(&stringNode);
+            if (SUCCEEDED(hr)) {
+                ComPtr<IXmlNode> appendedChild;
+                hr = node->AppendChild(stringNode.Get(), &appendedChild);
+            }
+        }
+        return hr;
+    }
+
+    inline HRESULT
+    setEventHandlers(_In_ IToastNotification *notification, _In_ const std::shared_ptr<IWinToastHandler> &eventHandler,
+                     _In_ INT64 expirationTime) {
+        EventRegistrationToken activatedToken, dismissedToken, failedToken;
+        HRESULT hr = notification->add_Activated(
+                Callback<Implements<RuntimeClassFlags<ClassicCom>,
+                        ITypedEventHandler<ToastNotification *, IInspectable * >>>(
+                        [eventHandler](IToastNotification *, IInspectable *inspectable) {
+                            IToastActivatedEventArgs *activatedEventArgs;
+                            HRESULT hr = inspectable->QueryInterface(&activatedEventArgs);
+                            if (SUCCEEDED(hr)) {
+                                HSTRING argumentsHandle;
+                                hr = activatedEventArgs->get_Arguments(&argumentsHandle);
+                                if (SUCCEEDED(hr)) {
+                                    PCWSTR arguments = Util::AsString(argumentsHandle);
+                                    if (arguments && *arguments) {
+                                        eventHandler->toastActivated(static_cast<int>(wcstol(arguments, nullptr, 10)));
+                                        return S_OK;
+                                    }
+                                }
+                            }
+                            eventHandler->toastActivated();
+                            return S_OK;
+                        }).Get(), &activatedToken);
+
+        if (SUCCEEDED(hr)) {
+            hr = notification->add_Dismissed(Callback<Implements<RuntimeClassFlags<ClassicCom>,
+                    ITypedEventHandler<ToastNotification *, ToastDismissedEventArgs * >>>(
+                    [eventHandler, expirationTime](IToastNotification *, IToastDismissedEventArgs *e) {
+                        ToastDismissalReason reason;
+                        if (SUCCEEDED(e->get_Reason(&reason))) {
+                            if (reason == ToastDismissalReason_UserCanceled && expirationTime &&
+                                InternalDateTime::Now() >= expirationTime)
+                                reason = ToastDismissalReason_TimedOut;
+                            eventHandler->toastDismissed(getWinToastDismissalReason(reason));
+                        }
+                        return S_OK;
+                    }).Get(), &dismissedToken);
+            if (SUCCEEDED(hr)) {
+                hr = notification->add_Failed(Callback<Implements<RuntimeClassFlags<ClassicCom>,
+                        ITypedEventHandler<ToastNotification *, ToastFailedEventArgs * >>>(
+                        [eventHandler](IToastNotification *, IToastFailedEventArgs *) {
+                            eventHandler->toastFailed();
+                            return S_OK;
+                        }).Get(), &failedToken);
+            }
+        }
+        return hr;
+    }
+
+    inline HRESULT addAttribute(_In_ IXmlDocument *xml, const std::wstring &name, IXmlNamedNodeMap *attributeMap) {
+        ComPtr<ABI::Windows::Data::Xml::Dom::IXmlAttribute> attribute;
+        HRESULT hr = xml->CreateAttribute(WinToastStringWrapper(name).Get(), &attribute);
+        if (SUCCEEDED(hr)) {
+            ComPtr<IXmlNode> node;
+            hr = attribute.As(&node);
+            if (SUCCEEDED(hr)) {
+                ComPtr<IXmlNode> pNode;
+                hr = attributeMap->SetNamedItem(node.Get(), &pNode);
+            }
+        }
+        return hr;
+    }
+
+    inline HRESULT
+    createElement(_In_ IXmlDocument *xml, _In_ const std::wstring &root_node, _In_ const std::wstring &element_name,
+                  _In_ const std::vector<std::wstring> &attribute_names) {
+        ComPtr<IXmlNodeList> rootList;
+        HRESULT hr = xml->GetElementsByTagName(WinToastStringWrapper(root_node).Get(), &rootList);
+        if (SUCCEEDED(hr)) {
+            ComPtr<IXmlNode> root;
+            hr = rootList->Item(0, &root);
+            if (SUCCEEDED(hr)) {
+                ComPtr<ABI::Windows::Data::Xml::Dom::IXmlElement> element;
+                hr = xml->CreateElement(WinToastStringWrapper(element_name).Get(), &element);
+                if (SUCCEEDED(hr)) {
+                    ComPtr<IXmlNode> nodeTmp;
+                    hr = element.As(&nodeTmp);
+                    if (SUCCEEDED(hr)) {
+                        ComPtr<IXmlNode> node;
+                        hr = root->AppendChild(nodeTmp.Get(), &node);
+                        if (SUCCEEDED(hr)) {
+                            ComPtr<IXmlNamedNodeMap> attributes;
+                            hr = node->get_Attributes(&attributes);
+                            if (SUCCEEDED(hr)) {
+                                for (const auto &it: attribute_names) {
+                                    hr = addAttribute(xml, it, attributes.Get());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return hr;
+    }
+}
+
+WinToastImpl &WinToastImpl::instance() {
+    static WinToastImpl instance;
+    return instance;
+}
+
+WinToastImpl::WinToastImpl() :
+        _isInitialized(false),
+        _hasCoInitialized(false) {
+    if (!isCompatible()) {
+        DEBUG_MSG(L"Warning: Your system is not compatible with this library ");
+    }
+}
+
+WinToastImpl::~WinToastImpl() {
+    if (_hasCoInitialized) {
+        CoUninitialize();
+    }
+}
+
+void WinToastImpl::setAppName(_In_ const std::wstring &appName) {
+    _appName = appName;
+}
+
+
+void WinToastImpl::setAppUserModelId(_In_ const std::wstring &aumi) {
+    _aumi = aumi;
+    DEBUG_MSG(L"Default App User Model Id: " << _aumi.c_str());
+}
+
+void WinToastImpl::setShortcutPolicy(_In_ WinToast::ShortcutPolicy shortcutPolicy) {
+    _shortcutPolicy = shortcutPolicy;
+}
+
+bool WinToastImpl::isCompatible() {
+    DllImporter::initialize();
+    return !((DllImporter::SetCurrentProcessExplicitAppUserModelID == nullptr)
+             || (DllImporter::PropVariantToString == nullptr)
+             || (DllImporter::RoGetActivationFactory == nullptr)
+             || (DllImporter::WindowsCreateStringReference == nullptr)
+             || (DllImporter::WindowsDeleteString == nullptr));
+}
+
+bool WinToastImpl::isSupportingModernFeatures() {
+    constexpr auto MinimumSupportedVersion = 6;
+    return Util::getRealOSVersion().dwMajorVersion > MinimumSupportedVersion;
+
+}
+
+std::wstring WinToastImpl::configureAUMI(_In_ const std::wstring &companyName,
+                                         _In_ const std::wstring &productName,
+                                         _In_ const std::wstring &subProduct,
+                                         _In_ const std::wstring &versionInformation) {
+    std::wstring aumi = companyName;
+    aumi += L"." + productName;
+    if (subProduct.length() > 0) {
+        aumi += L"." + subProduct;
+        if (versionInformation.length() > 0) {
+            aumi += L"." + versionInformation;
+        }
+    }
+
+    if (aumi.length() > SCHAR_MAX) {
+        DEBUG_MSG("Error: max size allowed for AUMI: 128 characters.");
+    }
+    return aumi;
+}
+
+enum WinToast::ShortcutResult WinToastImpl::createShortcut() {
+    if (_aumi.empty() || _appName.empty()) {
+        DEBUG_MSG(L"Error: App User Model Id or Appname is empty!");
+        return WinToast::ShortcutResult::SHORTCUT_MISSING_PARAMETERS;
+    }
+
+    if (!isCompatible()) {
+        DEBUG_MSG(L"Your OS is not compatible with this library! =(");
+        return WinToast::ShortcutResult::SHORTCUT_INCOMPATIBLE_OS;
+    }
+
+    if (!_hasCoInitialized) {
+        HRESULT initHr = CoInitializeEx(nullptr, COINIT::COINIT_MULTITHREADED);
+        if (initHr != RPC_E_CHANGED_MODE) {
+            if (FAILED(initHr) && initHr != S_FALSE) {
+                DEBUG_MSG(L"Error on COM library initialization!");
+                return WinToast::ShortcutResult::SHORTCUT_COM_INIT_FAILURE;
+            } else {
+                _hasCoInitialized = true;
+            }
+        }
+    }
+
+    bool wasChanged;
+    HRESULT hr = validateShellLinkHelper(wasChanged);
+    if (SUCCEEDED(hr))
+        return wasChanged ? WinToast::ShortcutResult::SHORTCUT_WAS_CHANGED
+                          : WinToast::ShortcutResult::SHORTCUT_UNCHANGED;
+
+    hr = createShellLinkHelper();
+    return SUCCEEDED(hr) ? WinToast::ShortcutResult::SHORTCUT_WAS_CREATED
+                         : WinToast::ShortcutResult::SHORTCUT_CREATE_FAILED;
+}
+
+bool WinToastImpl::initialize(_Out_opt_ WinToast::WinToastError *error) {
+    _isInitialized = false;
+    setError(error, WinToast::WinToastError::NoError);
+
+    if (!isCompatible()) {
+        setError(error, WinToast::WinToastError::SystemNotSupported);
+        DEBUG_MSG(L"Error: system not supported.");
+        return false;
+    }
+
+
+    if (_aumi.empty() || _appName.empty()) {
+        setError(error, WinToast::WinToastError::InvalidParameters);
+        DEBUG_MSG(L"Error while initializing, did you set up a valid AUMI and App name?");
+        return false;
+    }
+
+    if (_shortcutPolicy != WinToast::ShortcutPolicy::SHORTCUT_POLICY_IGNORE) {
+        if ((int) createShortcut() < 0) {
+            setError(error, WinToast::WinToastError::ShellLinkNotCreated);
+            DEBUG_MSG(L"Error while attaching the AUMI to the current proccess =(");
+            return false;
+        }
+    }
+
+    if (FAILED(DllImporter::SetCurrentProcessExplicitAppUserModelID(_aumi.c_str()))) {
+        setError(error, WinToast::WinToastError::InvalidAppUserModelID);
+        DEBUG_MSG(L"Error while attaching the AUMI to the current proccess =(");
+        return false;
+    }
+
+    _isInitialized = true;
+    return _isInitialized;
+}
+
+bool WinToastImpl::isInitialized() const {
+    return _isInitialized;
+}
+
+const std::wstring &WinToastImpl::appName() const {
+    return _appName;
+}
+
+const std::wstring &WinToastImpl::appUserModelId() const {
+    return _aumi;
+}
+
+
+HRESULT WinToastImpl::validateShellLinkHelper(_Out_ bool &wasChanged) {
+    WCHAR path[MAX_PATH] = {L'\0'};
+    Util::defaultShellLinkPath(_appName, path);
+    // Check if the file exist
+    DWORD attr = GetFileAttributesW(path);
+    if (attr >= 0xFFFFFFF) {
+        DEBUG_MSG("Error, shell link not found. Try to create a new one in: " << path);
+        return E_FAIL;
+    }
+
+    // Let's load the file as shell link to validate.
+    // - Create a shell link
+    // - Create a persistant file
+    // - Load the path as data for the persistant file
+    // - Read the property AUMI and validate with the current
+    // - Review if AUMI is equal.
+    ComPtr<IShellLink> shellLink;
+    HRESULT hr = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&shellLink));
+    if (SUCCEEDED(hr)) {
+        ComPtr<IPersistFile> persistFile;
+        hr = shellLink.As(&persistFile);
+        if (SUCCEEDED(hr)) {
+            hr = persistFile->Load(path, STGM_READWRITE);
+            if (SUCCEEDED(hr)) {
+                ComPtr<IPropertyStore> propertyStore;
+                hr = shellLink.As(&propertyStore);
+                if (SUCCEEDED(hr)) {
+                    PROPVARIANT appIdPropVar;
+                    hr = propertyStore->GetValue(PKEY_AppUserModel_ID, &appIdPropVar);
+                    if (SUCCEEDED(hr)) {
+                        WCHAR AUMI[MAX_PATH];
+                        hr = DllImporter::PropVariantToString(appIdPropVar, AUMI, MAX_PATH);
+                        wasChanged = false;
+                        if (FAILED(hr) || _aumi != AUMI) {
+                            if (_shortcutPolicy == WinToast::ShortcutPolicy::SHORTCUT_POLICY_REQUIRE_CREATE) {
+                                // AUMI Changed for the same app, let's update the current value! =)
+                                wasChanged = true;
+                                PropVariantClear(&appIdPropVar);
+                                hr = InitPropVariantFromString(_aumi.c_str(), &appIdPropVar);
+                                if (SUCCEEDED(hr)) {
+                                    hr = propertyStore->SetValue(PKEY_AppUserModel_ID, appIdPropVar);
+                                    if (SUCCEEDED(hr)) {
+                                        hr = propertyStore->Commit();
+                                        if (SUCCEEDED(hr) && SUCCEEDED(persistFile->IsDirty())) {
+                                            hr = persistFile->Save(path, TRUE);
+                                        }
+                                    }
+                                }
+                            } else {
+                                // Not allowed to touch the shortcut to fix the AUMI
+                                hr = E_FAIL;
+                            }
+                        }
+                        PropVariantClear(&appIdPropVar);
+                    }
+                }
+            }
+        }
+    }
+    return hr;
+}
+
+
+HRESULT WinToastImpl::createShellLinkHelper() {
+    if (_shortcutPolicy != WinToast::ShortcutPolicy::SHORTCUT_POLICY_REQUIRE_CREATE) {
+        return E_FAIL;
+    }
+
+    WCHAR exePath[MAX_PATH]{L'\0'};
+    WCHAR slPath[MAX_PATH]{L'\0'};
+    Util::defaultShellLinkPath(_appName, slPath);
+    Util::defaultExecutablePath(exePath);
+    ComPtr<IShellLinkW> shellLink;
+    HRESULT hr = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&shellLink));
+    if (SUCCEEDED(hr)) {
+        hr = shellLink->SetPath(exePath);
+        if (SUCCEEDED(hr)) {
+            hr = shellLink->SetArguments(L"");
+            if (SUCCEEDED(hr)) {
+                hr = shellLink->SetWorkingDirectory(exePath);
+                if (SUCCEEDED(hr)) {
+                    ComPtr<IPropertyStore> propertyStore;
+                    hr = shellLink.As(&propertyStore);
+                    if (SUCCEEDED(hr)) {
+                        PROPVARIANT appIdPropVar;
+                        hr = InitPropVariantFromString(_aumi.c_str(), &appIdPropVar);
+                        if (SUCCEEDED(hr)) {
+                            hr = propertyStore->SetValue(PKEY_AppUserModel_ID, appIdPropVar);
+                            if (SUCCEEDED(hr)) {
+                                hr = propertyStore->Commit();
+                                if (SUCCEEDED(hr)) {
+                                    ComPtr<IPersistFile> persistFile;
+                                    hr = shellLink.As(&persistFile);
+                                    if (SUCCEEDED(hr)) {
+                                        hr = persistFile->Save(slPath, TRUE);
+                                    }
+                                }
+                            }
+                            PropVariantClear(&appIdPropVar);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return hr;
+}
+
+INT64 WinToastImpl::showToast(_In_ const WinToastTemplate &toast, _In_  IWinToastHandler *handler, _Out_
+                              WinToast::WinToastError *error) {
+    setError(error, WinToast::WinToastError::NoError);
+    INT64 id = -1;
+    if (!isInitialized()) {
+        setError(error, WinToast::WinToastError::NotInitialized);
+        DEBUG_MSG("Error when launching the toast. WinToast is not initialized.");
+        return id;
+    }
+    if (!handler) {
+        setError(error, WinToast::WinToastError::InvalidHandler);
+        DEBUG_MSG("Error when launching the toast. Handler cannot be nullptr.");
+        return id;
+    }
+
+    ComPtr<IToastNotificationManagerStatics> notificationManager;
+    HRESULT hr = DllImporter::Wrap_GetActivationFactory(
+            WinToastStringWrapper(RuntimeClass_Windows_UI_Notifications_ToastNotificationManager).Get(),
+            &notificationManager);
+    if (SUCCEEDED(hr)) {
+        ComPtr<IToastNotifier> notifier;
+        hr = notificationManager->CreateToastNotifierWithId(WinToastStringWrapper(_aumi).Get(), &notifier);
+        if (SUCCEEDED(hr)) {
+            ComPtr<IToastNotificationFactory> notificationFactory;
+            hr = DllImporter::Wrap_GetActivationFactory(
+                    WinToastStringWrapper(RuntimeClass_Windows_UI_Notifications_ToastNotification).Get(),
+                    &notificationFactory);
+            if (SUCCEEDED(hr)) {
+                ComPtr<IXmlDocument> xmlDocument;
+                hr = notificationManager->GetTemplateContent(getToastTemplateType(toast.type()), &xmlDocument);
+                if (SUCCEEDED(hr)) {
+                    for (UINT32 i = 0, fieldsCount = static_cast<UINT32>(toast.textFieldsCount());
+                         i < fieldsCount && SUCCEEDED(hr); i++) {
+                        hr = setTextFieldHelper(xmlDocument.Get(), toast.textField(WinToastTemplate::TextField(i)), i);
+                    }
+
+                    // Modern feature are supported Windows > Windows 10
+                    if (SUCCEEDED(hr) && isSupportingModernFeatures()) {
+
+                        // Note that we do this *after* using toast.textFieldsCount() to
+                        // iterate/fill the template's text fields, since we're adding yet another text field.
+                        if (SUCCEEDED(hr)
+                            && !toast.attributionText().empty()) {
+                            hr = setAttributionTextFieldHelper(xmlDocument.Get(), toast.attributionText());
+                        }
+
+                        std::array<WCHAR, 12> buf{};
+                        for (std::size_t i = 0, actionsCount = toast.actionsCount();
+                             i < actionsCount && SUCCEEDED(hr); i++) {
+                            _snwprintf_s(buf.data(), buf.size(), _TRUNCATE, L"%zd", i);
+                            hr = addActionHelper(xmlDocument.Get(), toast.actionLabel(i), buf.data());
+                        }
+
+                        if (SUCCEEDED(hr)) {
+                            hr = (toast.audioPath().empty() &&
+                                  toast.audioOption() == WinToastTemplate::AudioOption::Default)
+                                 ? hr : setAudioFieldHelper(xmlDocument.Get(), toast.audioPath(), toast.audioOption());
+                        }
+
+                        if (SUCCEEDED(hr) && toast.duration() != WinToastTemplate::Duration::System) {
+                            hr = addDurationHelper(xmlDocument.Get(),
+                                                   (toast.duration() == WinToastTemplate::Duration::Short) ? L"short"
+                                                                                                           : L"long");
+                        }
+
+                        if (SUCCEEDED(hr)) {
+                            hr = addScenarioHelper(xmlDocument.Get(), toast.scenario());
+                        }
+
+                    } else {
+                        DEBUG_MSG("Modern features (Actions/Sounds/Attributes) not supported in this os version");
+                    }
+
+                    if (SUCCEEDED(hr)) {
+                        hr = toast.hasImage() ? setImageFieldHelper(xmlDocument.Get(), toast.imagePath()) : hr;
+                        if (SUCCEEDED(hr)) {
+                            ComPtr<IToastNotification> notification;
+                            hr = notificationFactory->CreateToastNotification(xmlDocument.Get(), &notification);
+                            if (SUCCEEDED(hr)) {
+                                INT64 expiration = 0, relativeExpiration = toast.expiration();
+                                if (relativeExpiration > 0) {
+                                    InternalDateTime expirationDateTime(relativeExpiration);
+                                    expiration = expirationDateTime;
+                                    hr = notification->put_ExpirationTime(&expirationDateTime);
+                                }
+
+                                if (SUCCEEDED(hr)) {
+                                    hr = Util::setEventHandlers(notification.Get(),
+                                                                std::shared_ptr<IWinToastHandler>(handler), expiration);
+                                    if (FAILED(hr)) {
+                                        setError(error, WinToast::WinToastError::InvalidHandler);
+                                    }
+                                }
+
+                                if (SUCCEEDED(hr)) {
+                                    GUID guid;
+                                    hr = CoCreateGuid(&guid);
+                                    if (SUCCEEDED(hr)) {
+                                        id = guid.Data1;
+                                        _buffer[id] = notification;
+                                        DEBUG_MSG("xml: " << Util::AsString(xmlDocument));
+                                        hr = notifier->Show(notification.Get());
+                                        if (FAILED(hr)) {
+                                            setError(error, WinToast::WinToastError::NotDisplayed);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return FAILED(hr) ? -1 : id;
+}
+
+ComPtr<IToastNotifier> WinToastImpl::notifier(_In_ bool *succeded) const {
+    ComPtr<IToastNotificationManagerStatics> notificationManager;
+    ComPtr<IToastNotifier> notifier;
+    HRESULT hr = DllImporter::Wrap_GetActivationFactory(
+            WinToastStringWrapper(RuntimeClass_Windows_UI_Notifications_ToastNotificationManager).Get(),
+            &notificationManager);
+    if (SUCCEEDED(hr)) {
+        hr = notificationManager->CreateToastNotifierWithId(WinToastStringWrapper(_aumi).Get(), &notifier);
+    }
+    *succeded = SUCCEEDED(hr);
+    return notifier;
+}
+
+bool WinToastImpl::hideToast(_In_ INT64 id) {
+    if (!isInitialized()) {
+        DEBUG_MSG("Error when hiding the toast. WinToast is not initialized.");
+        return false;
+    }
+
+    if (_buffer.find(id) != _buffer.end()) {
+        auto succeded = false;
+        auto notify = notifier(&succeded);
+        if (succeded) {
+            auto result = notify->Hide(_buffer[id].Get());
+            _buffer.erase(id);
+            return SUCCEEDED(result);
+        }
+    }
+    return false;
+}
+
+void WinToastImpl::clear() {
+    auto succeded = false;
+    auto notify = notifier(&succeded);
+    if (succeded) {
+        auto end = _buffer.end();
+        for (auto it = _buffer.begin(); it != end; ++it) {
+            notify->Hide(it->second.Get());
+        }
+        _buffer.clear();
+    }
+}
+
+//
+// Available as of Windows 10 Anniversary Update
+// Ref: https://docs.microsoft.com/en-us/windows/uwp/design/shell/tiles-and-notifications/adaptive-interactive-toasts
+//
+// NOTE: This will add a new text field, so be aware when iterating over
+//       the toast's text fields or getting a count of them.
+//
+HRESULT WinToastImpl::setAttributionTextFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &text) {
+    Util::createElement(xml, L"binding", L"text", {L"placement"});
+    ComPtr<IXmlNodeList> nodeList;
+    HRESULT hr = xml->GetElementsByTagName(WinToastStringWrapper(L"text").Get(), &nodeList);
+    if (SUCCEEDED(hr)) {
+        UINT32 nodeListLength;
+        hr = nodeList->get_Length(&nodeListLength);
+        if (SUCCEEDED(hr)) {
+            for (UINT32 i = 0; i < nodeListLength; i++) {
+                ComPtr<IXmlNode> textNode;
+                hr = nodeList->Item(i, &textNode);
+                if (SUCCEEDED(hr)) {
+                    ComPtr<IXmlNamedNodeMap> attributes;
+                    hr = textNode->get_Attributes(&attributes);
+                    if (SUCCEEDED(hr)) {
+                        ComPtr<IXmlNode> editedNode;
+                        if (SUCCEEDED(hr)) {
+                            hr = attributes->GetNamedItem(WinToastStringWrapper(L"placement").Get(), &editedNode);
+                            if (FAILED(hr) || !editedNode) {
+                                continue;
+                            }
+                            hr = Util::setNodeStringValue(L"attribution", editedNode.Get(), xml);
+                            if (SUCCEEDED(hr)) {
+                                return setTextFieldHelper(xml, text, i);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return hr;
+}
+
+HRESULT WinToastImpl::addDurationHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &duration) {
+    ComPtr<IXmlNodeList> nodeList;
+    HRESULT hr = xml->GetElementsByTagName(WinToastStringWrapper(L"toast").Get(), &nodeList);
+    if (SUCCEEDED(hr)) {
+        UINT32 length;
+        hr = nodeList->get_Length(&length);
+        if (SUCCEEDED(hr)) {
+            ComPtr<IXmlNode> toastNode;
+            hr = nodeList->Item(0, &toastNode);
+            if (SUCCEEDED(hr)) {
+                ComPtr<IXmlElement> toastElement;
+                hr = toastNode.As(&toastElement);
+                if (SUCCEEDED(hr)) {
+                    hr = toastElement->SetAttribute(WinToastStringWrapper(L"duration").Get(),
+                                                    WinToastStringWrapper(duration).Get());
+                }
+            }
+        }
+    }
+    return hr;
+}
+
+HRESULT WinToastImpl::addScenarioHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &scenario) {
+    ComPtr<IXmlNodeList> nodeList;
+    HRESULT hr = xml->GetElementsByTagName(WinToastStringWrapper(L"toast").Get(), &nodeList);
+    if (SUCCEEDED(hr)) {
+        UINT32 length;
+        hr = nodeList->get_Length(&length);
+        if (SUCCEEDED(hr)) {
+            ComPtr<IXmlNode> toastNode;
+            hr = nodeList->Item(0, &toastNode);
+            if (SUCCEEDED(hr)) {
+                ComPtr<IXmlElement> toastElement;
+                hr = toastNode.As(&toastElement);
+                if (SUCCEEDED(hr)) {
+                    hr = toastElement->SetAttribute(WinToastStringWrapper(L"scenario").Get(),
+                                                    WinToastStringWrapper(scenario).Get());
+                }
+            }
+        }
+    }
+    return hr;
+}
+
+HRESULT WinToastImpl::setTextFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &text, _In_ UINT32 pos) {
+    ComPtr<IXmlNodeList> nodeList;
+    HRESULT hr = xml->GetElementsByTagName(WinToastStringWrapper(L"text").Get(), &nodeList);
+    if (SUCCEEDED(hr)) {
+        ComPtr<IXmlNode> node;
+        hr = nodeList->Item(pos, &node);
+        if (SUCCEEDED(hr)) {
+            hr = Util::setNodeStringValue(text, node.Get(), xml);
+        }
+    }
+    return hr;
+}
+
+
+HRESULT WinToastImpl::setImageFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &path) {
+    assert(path.size() < MAX_PATH);
+
+    wchar_t imagePath[MAX_PATH] = L"file:///";
+    HRESULT hr = StringCchCatW(imagePath, MAX_PATH, path.c_str());
+    if (SUCCEEDED(hr)) {
+        ComPtr<IXmlNodeList> nodeList;
+        hr = xml->GetElementsByTagName(WinToastStringWrapper(L"image").Get(), &nodeList);
+        if (SUCCEEDED(hr)) {
+            ComPtr<IXmlNode> node;
+            hr = nodeList->Item(0, &node);
+            if (SUCCEEDED(hr)) {
+                ComPtr<IXmlNamedNodeMap> attributes;
+                hr = node->get_Attributes(&attributes);
+                if (SUCCEEDED(hr)) {
+                    ComPtr<IXmlNode> editedNode;
+                    hr = attributes->GetNamedItem(WinToastStringWrapper(L"src").Get(), &editedNode);
+                    if (SUCCEEDED(hr)) {
+                        Util::setNodeStringValue(imagePath, editedNode.Get(), xml);
+                    }
+                }
+            }
+        }
+    }
+    return hr;
+}
+
+HRESULT WinToastImpl::setAudioFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &path, _In_opt_
+                                          WinToastTemplate::AudioOption option) {
+    std::vector<std::wstring> attrs;
+    if (!path.empty()) attrs.emplace_back(L"src");
+    if (option == WinToastTemplate::AudioOption::Loop) attrs.emplace_back(L"loop");
+    if (option == WinToastTemplate::AudioOption::Silent) attrs.emplace_back(L"silent");
+    Util::createElement(xml, L"toast", L"audio", attrs);
+
+    ComPtr<IXmlNodeList> nodeList;
+    HRESULT hr = xml->GetElementsByTagName(WinToastStringWrapper(L"audio").Get(), &nodeList);
+    if (SUCCEEDED(hr)) {
+        ComPtr<IXmlNode> node;
+        hr = nodeList->Item(0, &node);
+        if (SUCCEEDED(hr)) {
+            ComPtr<IXmlNamedNodeMap> attributes;
+            hr = node->get_Attributes(&attributes);
+            if (SUCCEEDED(hr)) {
+                ComPtr<IXmlNode> editedNode;
+                if (!path.empty()) {
+                    if (SUCCEEDED(hr)) {
+                        hr = attributes->GetNamedItem(WinToastStringWrapper(L"src").Get(), &editedNode);
+                        if (SUCCEEDED(hr)) {
+                            hr = Util::setNodeStringValue(path, editedNode.Get(), xml);
+                        }
+                    }
+                }
+
+                if (SUCCEEDED(hr)) {
+                    switch (option) {
+                        case WinToastTemplate::AudioOption::Loop:
+                            hr = attributes->GetNamedItem(WinToastStringWrapper(L"loop").Get(), &editedNode);
+                            if (SUCCEEDED(hr)) {
+                                hr = Util::setNodeStringValue(L"true", editedNode.Get(), xml);
+                            }
+                            break;
+                        case WinToastTemplate::AudioOption::Silent:
+                            hr = attributes->GetNamedItem(WinToastStringWrapper(L"silent").Get(), &editedNode);
+                            if (SUCCEEDED(hr)) {
+                                hr = Util::setNodeStringValue(L"true", editedNode.Get(), xml);
+                            }
+                        default:
+                            break;
+                    }
+                }
+            }
+        }
+    }
+    return hr;
+}
+
+HRESULT WinToastImpl::addActionHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &content, _In_
+                                      const std::wstring &arguments) {
+    ComPtr<IXmlNodeList> nodeList;
+    HRESULT hr = xml->GetElementsByTagName(WinToastStringWrapper(L"actions").Get(), &nodeList);
+    if (SUCCEEDED(hr)) {
+        UINT32 length;
+        hr = nodeList->get_Length(&length);
+        if (SUCCEEDED(hr)) {
+            ComPtr<IXmlNode> actionsNode;
+            if (length > 0) {
+                hr = nodeList->Item(0, &actionsNode);
+            } else {
+                hr = xml->GetElementsByTagName(WinToastStringWrapper(L"toast").Get(), &nodeList);
+                if (SUCCEEDED(hr)) {
+                    hr = nodeList->get_Length(&length);
+                    if (SUCCEEDED(hr)) {
+                        ComPtr<IXmlNode> toastNode;
+                        hr = nodeList->Item(0, &toastNode);
+                        if (SUCCEEDED(hr)) {
+                            ComPtr<IXmlElement> toastElement;
+                            hr = toastNode.As(&toastElement);
+                            if (SUCCEEDED(hr))
+                                hr = toastElement->SetAttribute(WinToastStringWrapper(L"template").Get(),
+                                                                WinToastStringWrapper(L"ToastGeneric").Get());
+                            if (SUCCEEDED(hr))
+                                hr = toastElement->SetAttribute(WinToastStringWrapper(L"duration").Get(),
+                                                                WinToastStringWrapper(L"long").Get());
+                            if (SUCCEEDED(hr)) {
+                                ComPtr<IXmlElement> actionsElement;
+                                hr = xml->CreateElement(WinToastStringWrapper(L"actions").Get(), &actionsElement);
+                                if (SUCCEEDED(hr)) {
+                                    hr = actionsElement.As(&actionsNode);
+                                    if (SUCCEEDED(hr)) {
+                                        ComPtr<IXmlNode> appendedChild;
+                                        hr = toastNode->AppendChild(actionsNode.Get(), &appendedChild);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if (SUCCEEDED(hr)) {
+                ComPtr<IXmlElement> actionElement;
+                hr = xml->CreateElement(WinToastStringWrapper(L"action").Get(), &actionElement);
+                if (SUCCEEDED(hr))
+                    hr = actionElement->SetAttribute(WinToastStringWrapper(L"content").Get(),
+                                                     WinToastStringWrapper(content).Get());
+                if (SUCCEEDED(hr))
+                    hr = actionElement->SetAttribute(WinToastStringWrapper(L"arguments").Get(),
+                                                     WinToastStringWrapper(arguments).Get());
+                if (SUCCEEDED(hr)) {
+                    ComPtr<IXmlNode> actionNode;
+                    hr = actionElement.As(&actionNode);
+                    if (SUCCEEDED(hr)) {
+                        ComPtr<IXmlNode> appendedChild;
+                        hr = actionsNode->AppendChild(actionNode.Get(), &appendedChild);
+                    }
+                }
+            }
+        }
+    }
+    return hr;
+}
+
+void WinToastImpl::setError(_Out_opt_ WinToast::WinToastError *error, _In_ WinToast::WinToastError value) {
+    if (error) {
+        *error = value;
+    }
+}

--- a/src/wintoast_impl.h
+++ b/src/wintoast_impl.h
@@ -1,0 +1,117 @@
+/* * Copyright (C) 2016-2019 Mohammed Boujemaoui <mohabouje@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef WINTOAST_WINTOAST_IMPL_H
+#define WINTOAST_WINTOAST_IMPL_H
+
+#include <Windows.h>
+#include <ShObjIdl.h>
+#include <wrl/implements.h>
+#include <windows.ui.notifications.h>
+
+#include <map>
+
+#include "wintoastlib.h"
+
+using namespace Microsoft::WRL;
+using namespace ABI::Windows::Data::Xml::Dom;
+using namespace ABI::Windows::Foundation;
+using namespace ABI::Windows::UI::Notifications;
+using namespace Windows::Foundation;
+
+namespace WinToastLib {
+
+    class WinToastImpl {
+    public:
+        WinToastImpl();
+
+        virtual ~WinToastImpl();
+
+        static WinToastImpl &instance();
+
+        static bool isCompatible();
+
+        static bool isSupportingModernFeatures();
+
+        static std::wstring configureAUMI(_In_ const std::wstring &companyName,
+                                          _In_ const std::wstring &productName,
+                                          _In_ const std::wstring &subProduct = std::wstring(),
+                                          _In_ const std::wstring &versionInformation = std::wstring());
+
+        static const std::wstring &strerror(_In_ WinToast::WinToastError error);
+
+        virtual bool initialize(_Out_opt_ WinToast::WinToastError *error = nullptr);
+
+        virtual bool isInitialized() const;
+
+        virtual bool hideToast(_In_ INT64 id);
+
+        virtual INT64 showToast(_In_ const WinToastTemplate &toast, _In_ IWinToastHandler *handler, _Out_opt_
+                                WinToast::WinToastError *error = nullptr);
+
+        virtual void clear();
+
+        virtual WinToast::ShortcutResult createShortcut();
+
+        const std::wstring &appName() const;
+
+        const std::wstring &appUserModelId() const;
+
+        void setAppUserModelId(_In_ const std::wstring &aumi);
+
+        void setAppName(_In_ const std::wstring &appName);
+
+        void setShortcutPolicy(_In_ WinToast::ShortcutPolicy policy);
+
+    protected:
+        bool _isInitialized{false};
+        bool _hasCoInitialized{false};
+        WinToast::ShortcutPolicy _shortcutPolicy{WinToast::ShortcutPolicy::SHORTCUT_POLICY_REQUIRE_CREATE};
+        std::wstring _appName{};
+        std::wstring _aumi{};
+        std::map<INT64, ComPtr<IToastNotification>> _buffer{};
+
+        HRESULT validateShellLinkHelper(_Out_ bool &wasChanged);
+
+        HRESULT createShellLinkHelper();
+
+        HRESULT setImageFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &path);
+
+        HRESULT setAudioFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &path, _In_opt_
+                                    WinToastTemplate::AudioOption option = WinToastTemplate::AudioOption::Default);
+
+        HRESULT setTextFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &text, _In_ UINT32 pos);
+
+        HRESULT setAttributionTextFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &text);
+
+        HRESULT
+        addActionHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &action, _In_ const std::wstring &arguments);
+
+        HRESULT addDurationHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &duration);
+
+        HRESULT addScenarioHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &scenario);
+
+        ComPtr<IToastNotifier> notifier(_In_ bool *succeded) const;
+
+        void setError(_Out_opt_ WinToast::WinToastError *error, _In_ WinToast::WinToastError value);
+    };
+}
+
+#endif //WINTOAST_WINTOAST_IMPL_H

--- a/src/wintoastlib.cpp
+++ b/src/wintoastlib.cpp
@@ -20,277 +20,46 @@
 
 #include "wintoastlib.h"
 
-#include <memory>
 #include <cassert>
 #include <unordered_map>
-#include <array>
 
-#include "dll_importer.h"
-#include "wintoast_string_wrapper.h"
-#include "internal_date_time.h"
+#include "wintoast_impl.h"
 
-#pragma comment(lib, "shlwapi")
-#pragma comment(lib, "user32")
-
-#ifdef NDEBUG
-#define DEBUG_MSG(str)
-#else
-#define DEBUG_MSG(str) std::wcout << str << std::endl
-#endif
-
-#define DEFAULT_SHELL_LINKS_PATH    L"\\Microsoft\\Windows\\Start Menu\\Programs\\"
-#define DEFAULT_LINK_FORMAT            L".lnk"
-#define STATUS_SUCCESS (0x00000000)
-
-
-// Quickstart: Handling toast activations from Win32 apps in Windows 10
-// https://blogs.msdn.microsoft.com/tiles_and_toasts/2015/10/16/quickstart-handling-toast-activations-from-win32-apps-in-windows-10/
 using namespace WinToastLib;
 
-namespace Util {
-
-    typedef LONG NTSTATUS, *PNTSTATUS;
-
-    typedef NTSTATUS(WINAPI *RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
-
-    inline RTL_OSVERSIONINFOW getRealOSVersion() {
-        HMODULE hMod = ::GetModuleHandleW(L"ntdll.dll");
-        if (hMod) {
-            RtlGetVersionPtr fxPtr = (RtlGetVersionPtr) ::GetProcAddress(hMod, "RtlGetVersion");
-            if (fxPtr != nullptr) {
-                RTL_OSVERSIONINFOW rovi = {0};
-                rovi.dwOSVersionInfoSize = sizeof(rovi);
-                if (STATUS_SUCCESS == fxPtr(&rovi)) {
-                    return rovi;
-                }
-            }
-        }
-        RTL_OSVERSIONINFOW rovi = {0};
-        return rovi;
-    }
-
-    inline HRESULT defaultExecutablePath(_In_ WCHAR *path, _In_ DWORD nSize = MAX_PATH) {
-        DWORD written = GetModuleFileNameExW(GetCurrentProcess(), nullptr, path, nSize);
-        DEBUG_MSG("Default executable path: " << path);
-        return (written > 0) ? S_OK : E_FAIL;
-    }
-
-
-    inline HRESULT defaultShellLinksDirectory(_In_ WCHAR *path, _In_ DWORD nSize = MAX_PATH) {
-        DWORD written = GetEnvironmentVariableW(L"APPDATA", path, nSize);
-        HRESULT hr = written > 0 ? S_OK : E_INVALIDARG;
-        if (SUCCEEDED(hr)) {
-            errno_t result = wcscat_s(path, nSize, DEFAULT_SHELL_LINKS_PATH);
-            hr = (result == 0) ? S_OK : E_INVALIDARG;
-            DEBUG_MSG("Default shell link path: " << path);
-        }
-        return hr;
-    }
-
-    inline HRESULT defaultShellLinkPath(const std::wstring &appname, _In_ WCHAR *path, _In_ DWORD nSize = MAX_PATH) {
-        HRESULT hr = defaultShellLinksDirectory(path, nSize);
-        if (SUCCEEDED(hr)) {
-            const std::wstring appLink(appname + DEFAULT_LINK_FORMAT);
-            errno_t result = wcscat_s(path, nSize, appLink.c_str());
-            hr = (result == 0) ? S_OK : E_INVALIDARG;
-            DEBUG_MSG("Default shell link file path: " << path);
-        }
-        return hr;
-    }
-
-
-    inline PCWSTR AsString(ComPtr<IXmlDocument> &xmlDocument) {
-        HSTRING xml;
-        ComPtr<IXmlNodeSerializer> ser;
-        HRESULT hr = xmlDocument.As<IXmlNodeSerializer>(&ser);
-        hr = ser->GetXml(&xml);
-        if (SUCCEEDED(hr))
-            return DllImporter::WindowsGetStringRawBuffer(xml, nullptr);
-        return nullptr;
-    }
-
-    inline PCWSTR AsString(HSTRING hstring) {
-        return DllImporter::WindowsGetStringRawBuffer(hstring, nullptr);
-    }
-
-    inline HRESULT setNodeStringValue(const std::wstring &string, IXmlNode *node, IXmlDocument *xml) {
-        ComPtr<IXmlText> textNode;
-        HRESULT hr = xml->CreateTextNode(WinToastStringWrapper(string).Get(), &textNode);
-        if (SUCCEEDED(hr)) {
-            ComPtr<IXmlNode> stringNode;
-            hr = textNode.As(&stringNode);
-            if (SUCCEEDED(hr)) {
-                ComPtr<IXmlNode> appendedChild;
-                hr = node->AppendChild(stringNode.Get(), &appendedChild);
-            }
-        }
-        return hr;
-    }
-
-    inline HRESULT
-    setEventHandlers(_In_ IToastNotification *notification, _In_ const std::shared_ptr<IWinToastHandler> &eventHandler,
-                     _In_ INT64 expirationTime) {
-        EventRegistrationToken activatedToken, dismissedToken, failedToken;
-        HRESULT hr = notification->add_Activated(
-                Callback<Implements<RuntimeClassFlags<ClassicCom>,
-                        ITypedEventHandler<ToastNotification *, IInspectable * >>>(
-                        [eventHandler](IToastNotification *, IInspectable *inspectable) {
-                            IToastActivatedEventArgs *activatedEventArgs;
-                            HRESULT hr = inspectable->QueryInterface(&activatedEventArgs);
-                            if (SUCCEEDED(hr)) {
-                                HSTRING argumentsHandle;
-                                hr = activatedEventArgs->get_Arguments(&argumentsHandle);
-                                if (SUCCEEDED(hr)) {
-                                    PCWSTR arguments = Util::AsString(argumentsHandle);
-                                    if (arguments && *arguments) {
-                                        eventHandler->toastActivated(static_cast<int>(wcstol(arguments, nullptr, 10)));
-                                        return S_OK;
-                                    }
-                                }
-                            }
-                            eventHandler->toastActivated();
-                            return S_OK;
-                        }).Get(), &activatedToken);
-
-        if (SUCCEEDED(hr)) {
-            hr = notification->add_Dismissed(Callback<Implements<RuntimeClassFlags<ClassicCom>,
-                    ITypedEventHandler<ToastNotification *, ToastDismissedEventArgs * >>>(
-                    [eventHandler, expirationTime](IToastNotification *, IToastDismissedEventArgs *e) {
-                        ToastDismissalReason reason;
-                        if (SUCCEEDED(e->get_Reason(&reason))) {
-                            if (reason == ToastDismissalReason_UserCanceled && expirationTime &&
-                                InternalDateTime::Now() >= expirationTime)
-                                reason = ToastDismissalReason_TimedOut;
-                            eventHandler->toastDismissed(
-                                    static_cast<IWinToastHandler::WinToastDismissalReason>(reason));
-                        }
-                        return S_OK;
-                    }).Get(), &dismissedToken);
-            if (SUCCEEDED(hr)) {
-                hr = notification->add_Failed(Callback<Implements<RuntimeClassFlags<ClassicCom>,
-                        ITypedEventHandler<ToastNotification *, ToastFailedEventArgs * >>>(
-                        [eventHandler](IToastNotification *, IToastFailedEventArgs *) {
-                            eventHandler->toastFailed();
-                            return S_OK;
-                        }).Get(), &failedToken);
-            }
-        }
-        return hr;
-    }
-
-    inline HRESULT addAttribute(_In_ IXmlDocument *xml, const std::wstring &name, IXmlNamedNodeMap *attributeMap) {
-        ComPtr<ABI::Windows::Data::Xml::Dom::IXmlAttribute> attribute;
-        HRESULT hr = xml->CreateAttribute(WinToastStringWrapper(name).Get(), &attribute);
-        if (SUCCEEDED(hr)) {
-            ComPtr<IXmlNode> node;
-            hr = attribute.As(&node);
-            if (SUCCEEDED(hr)) {
-                ComPtr<IXmlNode> pNode;
-                hr = attributeMap->SetNamedItem(node.Get(), &pNode);
-            }
-        }
-        return hr;
-    }
-
-    inline HRESULT
-    createElement(_In_ IXmlDocument *xml, _In_ const std::wstring &root_node, _In_ const std::wstring &element_name,
-                  _In_ const std::vector<std::wstring> &attribute_names) {
-        ComPtr<IXmlNodeList> rootList;
-        HRESULT hr = xml->GetElementsByTagName(WinToastStringWrapper(root_node).Get(), &rootList);
-        if (SUCCEEDED(hr)) {
-            ComPtr<IXmlNode> root;
-            hr = rootList->Item(0, &root);
-            if (SUCCEEDED(hr)) {
-                ComPtr<ABI::Windows::Data::Xml::Dom::IXmlElement> element;
-                hr = xml->CreateElement(WinToastStringWrapper(element_name).Get(), &element);
-                if (SUCCEEDED(hr)) {
-                    ComPtr<IXmlNode> nodeTmp;
-                    hr = element.As(&nodeTmp);
-                    if (SUCCEEDED(hr)) {
-                        ComPtr<IXmlNode> node;
-                        hr = root->AppendChild(nodeTmp.Get(), &node);
-                        if (SUCCEEDED(hr)) {
-                            ComPtr<IXmlNamedNodeMap> attributes;
-                            hr = node->get_Attributes(&attributes);
-                            if (SUCCEEDED(hr)) {
-                                for (const auto &it: attribute_names) {
-                                    hr = addAttribute(xml, it, attributes.Get());
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        return hr;
-    }
-}
+WinToastImpl &WinToast::winToastImpl = WinToastImpl::instance();
 
 WinToast *WinToast::instance() {
     static WinToast instance;
     return &instance;
 }
 
-WinToast::WinToast() :
-        _isInitialized(false),
-        _hasCoInitialized(false) {
-    if (!isCompatible()) {
-        DEBUG_MSG(L"Warning: Your system is not compatible with this library ");
-    }
-}
-
-WinToast::~WinToast() {
-    if (_hasCoInitialized) {
-        CoUninitialize();
-    }
-}
-
-void WinToast::setAppName(_In_ const std::wstring &appName) {
-    _appName = appName;
+void WinToast::setAppName(const std::wstring &appName) {
+    winToastImpl.setAppName(appName);
 }
 
 
-void WinToast::setAppUserModelId(_In_ const std::wstring &aumi) {
-    _aumi = aumi;
-    DEBUG_MSG(L"Default App User Model Id: " << _aumi.c_str());
+void WinToast::setAppUserModelId(const std::wstring &aumi) {
+    winToastImpl.setAppUserModelId(aumi);
 }
 
-void WinToast::setShortcutPolicy(_In_ ShortcutPolicy shortcutPolicy) {
-    _shortcutPolicy = shortcutPolicy;
+void WinToast::setShortcutPolicy(ShortcutPolicy shortcutPolicy) {
+    winToastImpl.setShortcutPolicy(shortcutPolicy);
 }
 
 bool WinToast::isCompatible() {
-    DllImporter::initialize();
-    return !((DllImporter::SetCurrentProcessExplicitAppUserModelID == nullptr)
-             || (DllImporter::PropVariantToString == nullptr)
-             || (DllImporter::RoGetActivationFactory == nullptr)
-             || (DllImporter::WindowsCreateStringReference == nullptr)
-             || (DllImporter::WindowsDeleteString == nullptr));
+    return winToastImpl.isCompatible();
 }
 
-bool WinToastLib::WinToast::isSupportingModernFeatures() {
-    constexpr auto MinimumSupportedVersion = 6;
-    return Util::getRealOSVersion().dwMajorVersion > MinimumSupportedVersion;
-
+bool WinToast::isSupportingModernFeatures() {
+    return winToastImpl.isSupportingModernFeatures();
 }
 
-std::wstring WinToast::configureAUMI(_In_ const std::wstring &companyName,
-                                     _In_ const std::wstring &productName,
-                                     _In_ const std::wstring &subProduct,
-                                     _In_ const std::wstring &versionInformation) {
-    std::wstring aumi = companyName;
-    aumi += L"." + productName;
-    if (subProduct.length() > 0) {
-        aumi += L"." + subProduct;
-        if (versionInformation.length() > 0) {
-            aumi += L"." + versionInformation;
-        }
-    }
-
-    if (aumi.length() > SCHAR_MAX) {
-        DEBUG_MSG("Error: max size allowed for AUMI: 128 characters.");
-    }
-    return aumi;
+std::wstring WinToast::configureAUMI(const std::wstring &companyName,
+                                     const std::wstring &productName,
+                                     const std::wstring &subProduct,
+                                     const std::wstring &versionInformation) {
+    return winToastImpl.configureAUMI(companyName, productName, subProduct, versionInformation);
 }
 
 const std::wstring &WinToast::strerror(WinToastError error) {
@@ -311,601 +80,38 @@ const std::wstring &WinToast::strerror(WinToastError error) {
 }
 
 enum WinToast::ShortcutResult WinToast::createShortcut() {
-    if (_aumi.empty() || _appName.empty()) {
-        DEBUG_MSG(L"Error: App User Model Id or Appname is empty!");
-        return ShortcutResult::SHORTCUT_MISSING_PARAMETERS;
-    }
-
-    if (!isCompatible()) {
-        DEBUG_MSG(L"Your OS is not compatible with this library! =(");
-        return ShortcutResult::SHORTCUT_INCOMPATIBLE_OS;
-    }
-
-    if (!_hasCoInitialized) {
-        HRESULT initHr = CoInitializeEx(nullptr, COINIT::COINIT_MULTITHREADED);
-        if (initHr != RPC_E_CHANGED_MODE) {
-            if (FAILED(initHr) && initHr != S_FALSE) {
-                DEBUG_MSG(L"Error on COM library initialization!");
-                return ShortcutResult::SHORTCUT_COM_INIT_FAILURE;
-            } else {
-                _hasCoInitialized = true;
-            }
-        }
-    }
-
-    bool wasChanged;
-    HRESULT hr = validateShellLinkHelper(wasChanged);
-    if (SUCCEEDED(hr))
-        return wasChanged ? ShortcutResult::SHORTCUT_WAS_CHANGED : ShortcutResult::SHORTCUT_UNCHANGED;
-
-    hr = createShellLinkHelper();
-    return SUCCEEDED(hr) ? ShortcutResult::SHORTCUT_WAS_CREATED : ShortcutResult::SHORTCUT_CREATE_FAILED;
+    return winToastImpl.createShortcut();
 }
 
-bool WinToast::initialize(_Out_opt_ WinToastError *error) {
-    _isInitialized = false;
-    setError(error, WinToastError::NoError);
-
-    if (!isCompatible()) {
-        setError(error, WinToastError::SystemNotSupported);
-        DEBUG_MSG(L"Error: system not supported.");
-        return false;
-    }
-
-
-    if (_aumi.empty() || _appName.empty()) {
-        setError(error, WinToastError::InvalidParameters);
-        DEBUG_MSG(L"Error while initializing, did you set up a valid AUMI and App name?");
-        return false;
-    }
-
-    if (_shortcutPolicy != ShortcutPolicy::SHORTCUT_POLICY_IGNORE) {
-        if ((int) createShortcut() < 0) {
-            setError(error, WinToastError::ShellLinkNotCreated);
-            DEBUG_MSG(L"Error while attaching the AUMI to the current proccess =(");
-            return false;
-        }
-    }
-
-    if (FAILED(DllImporter::SetCurrentProcessExplicitAppUserModelID(_aumi.c_str()))) {
-        setError(error, WinToastError::InvalidAppUserModelID);
-        DEBUG_MSG(L"Error while attaching the AUMI to the current proccess =(");
-        return false;
-    }
-
-    _isInitialized = true;
-    return _isInitialized;
+bool WinToast::initialize(WinToastError *error) {
+    return winToastImpl.initialize(error);
 }
 
 bool WinToast::isInitialized() const {
-    return _isInitialized;
+    return winToastImpl.isInitialized();
 }
 
 const std::wstring &WinToast::appName() const {
-    return _appName;
+    return winToastImpl.appName();
 }
 
 const std::wstring &WinToast::appUserModelId() const {
-    return _aumi;
+    return winToastImpl.appUserModelId();
 }
 
-
-HRESULT WinToast::validateShellLinkHelper(_Out_ bool &wasChanged) {
-    WCHAR path[MAX_PATH] = {L'\0'};
-    Util::defaultShellLinkPath(_appName, path);
-    // Check if the file exist
-    DWORD attr = GetFileAttributesW(path);
-    if (attr >= 0xFFFFFFF) {
-        DEBUG_MSG("Error, shell link not found. Try to create a new one in: " << path);
-        return E_FAIL;
-    }
-
-    // Let's load the file as shell link to validate.
-    // - Create a shell link
-    // - Create a persistant file
-    // - Load the path as data for the persistant file
-    // - Read the property AUMI and validate with the current
-    // - Review if AUMI is equal.
-    ComPtr<IShellLink> shellLink;
-    HRESULT hr = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&shellLink));
-    if (SUCCEEDED(hr)) {
-        ComPtr<IPersistFile> persistFile;
-        hr = shellLink.As(&persistFile);
-        if (SUCCEEDED(hr)) {
-            hr = persistFile->Load(path, STGM_READWRITE);
-            if (SUCCEEDED(hr)) {
-                ComPtr<IPropertyStore> propertyStore;
-                hr = shellLink.As(&propertyStore);
-                if (SUCCEEDED(hr)) {
-                    PROPVARIANT appIdPropVar;
-                    hr = propertyStore->GetValue(PKEY_AppUserModel_ID, &appIdPropVar);
-                    if (SUCCEEDED(hr)) {
-                        WCHAR AUMI[MAX_PATH];
-                        hr = DllImporter::PropVariantToString(appIdPropVar, AUMI, MAX_PATH);
-                        wasChanged = false;
-                        if (FAILED(hr) || _aumi != AUMI) {
-                            if (_shortcutPolicy == ShortcutPolicy::SHORTCUT_POLICY_REQUIRE_CREATE) {
-                                // AUMI Changed for the same app, let's update the current value! =)
-                                wasChanged = true;
-                                PropVariantClear(&appIdPropVar);
-                                hr = InitPropVariantFromString(_aumi.c_str(), &appIdPropVar);
-                                if (SUCCEEDED(hr)) {
-                                    hr = propertyStore->SetValue(PKEY_AppUserModel_ID, appIdPropVar);
-                                    if (SUCCEEDED(hr)) {
-                                        hr = propertyStore->Commit();
-                                        if (SUCCEEDED(hr) && SUCCEEDED(persistFile->IsDirty())) {
-                                            hr = persistFile->Save(path, TRUE);
-                                        }
-                                    }
-                                }
-                            } else {
-                                // Not allowed to touch the shortcut to fix the AUMI
-                                hr = E_FAIL;
-                            }
-                        }
-                        PropVariantClear(&appIdPropVar);
-                    }
-                }
-            }
-        }
-    }
-    return hr;
+INT64 WinToast::showToast(const WinToastTemplate &toast, IWinToastHandler *handler, WinToastError *error) {
+    return winToastImpl.showToast(toast, handler, error);
 }
 
-
-HRESULT WinToast::createShellLinkHelper() {
-    if (_shortcutPolicy != ShortcutPolicy::SHORTCUT_POLICY_REQUIRE_CREATE) {
-        return E_FAIL;
-    }
-
-    WCHAR exePath[MAX_PATH]{L'\0'};
-    WCHAR slPath[MAX_PATH]{L'\0'};
-    Util::defaultShellLinkPath(_appName, slPath);
-    Util::defaultExecutablePath(exePath);
-    ComPtr<IShellLinkW> shellLink;
-    HRESULT hr = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&shellLink));
-    if (SUCCEEDED(hr)) {
-        hr = shellLink->SetPath(exePath);
-        if (SUCCEEDED(hr)) {
-            hr = shellLink->SetArguments(L"");
-            if (SUCCEEDED(hr)) {
-                hr = shellLink->SetWorkingDirectory(exePath);
-                if (SUCCEEDED(hr)) {
-                    ComPtr<IPropertyStore> propertyStore;
-                    hr = shellLink.As(&propertyStore);
-                    if (SUCCEEDED(hr)) {
-                        PROPVARIANT appIdPropVar;
-                        hr = InitPropVariantFromString(_aumi.c_str(), &appIdPropVar);
-                        if (SUCCEEDED(hr)) {
-                            hr = propertyStore->SetValue(PKEY_AppUserModel_ID, appIdPropVar);
-                            if (SUCCEEDED(hr)) {
-                                hr = propertyStore->Commit();
-                                if (SUCCEEDED(hr)) {
-                                    ComPtr<IPersistFile> persistFile;
-                                    hr = shellLink.As(&persistFile);
-                                    if (SUCCEEDED(hr)) {
-                                        hr = persistFile->Save(slPath, TRUE);
-                                    }
-                                }
-                            }
-                            PropVariantClear(&appIdPropVar);
-                        }
-                    }
-                }
-            }
-        }
-    }
-    return hr;
-}
-
-INT64
-WinToast::showToast(_In_ const WinToastTemplate &toast, _In_  IWinToastHandler *handler, _Out_ WinToastError *error) {
-    setError(error, WinToastError::NoError);
-    INT64 id = -1;
-    if (!isInitialized()) {
-        setError(error, WinToastError::NotInitialized);
-        DEBUG_MSG("Error when launching the toast. WinToast is not initialized.");
-        return id;
-    }
-    if (!handler) {
-        setError(error, WinToastError::InvalidHandler);
-        DEBUG_MSG("Error when launching the toast. Handler cannot be nullptr.");
-        return id;
-    }
-
-    ComPtr<IToastNotificationManagerStatics> notificationManager;
-    HRESULT hr = DllImporter::Wrap_GetActivationFactory(
-            WinToastStringWrapper(RuntimeClass_Windows_UI_Notifications_ToastNotificationManager).Get(),
-            &notificationManager);
-    if (SUCCEEDED(hr)) {
-        ComPtr<IToastNotifier> notifier;
-        hr = notificationManager->CreateToastNotifierWithId(WinToastStringWrapper(_aumi).Get(), &notifier);
-        if (SUCCEEDED(hr)) {
-            ComPtr<IToastNotificationFactory> notificationFactory;
-            hr = DllImporter::Wrap_GetActivationFactory(
-                    WinToastStringWrapper(RuntimeClass_Windows_UI_Notifications_ToastNotification).Get(),
-                    &notificationFactory);
-            if (SUCCEEDED(hr)) {
-                ComPtr<IXmlDocument> xmlDocument;
-                hr = notificationManager->GetTemplateContent(ToastTemplateType(toast.type()), &xmlDocument);
-                if (SUCCEEDED(hr)) {
-                    for (UINT32 i = 0, fieldsCount = static_cast<UINT32>(toast.textFieldsCount());
-                         i < fieldsCount && SUCCEEDED(hr); i++) {
-                        hr = setTextFieldHelper(xmlDocument.Get(), toast.textField(WinToastTemplate::TextField(i)), i);
-                    }
-
-                    // Modern feature are supported Windows > Windows 10
-                    if (SUCCEEDED(hr) && isSupportingModernFeatures()) {
-
-                        // Note that we do this *after* using toast.textFieldsCount() to
-                        // iterate/fill the template's text fields, since we're adding yet another text field.
-                        if (SUCCEEDED(hr)
-                            && !toast.attributionText().empty()) {
-                            hr = setAttributionTextFieldHelper(xmlDocument.Get(), toast.attributionText());
-                        }
-
-                        std::array<WCHAR, 12> buf{};
-                        for (std::size_t i = 0, actionsCount = toast.actionsCount();
-                             i < actionsCount && SUCCEEDED(hr); i++) {
-                            _snwprintf_s(buf.data(), buf.size(), _TRUNCATE, L"%zd", i);
-                            hr = addActionHelper(xmlDocument.Get(), toast.actionLabel(i), buf.data());
-                        }
-
-                        if (SUCCEEDED(hr)) {
-                            hr = (toast.audioPath().empty() &&
-                                  toast.audioOption() == WinToastTemplate::AudioOption::Default)
-                                 ? hr : setAudioFieldHelper(xmlDocument.Get(), toast.audioPath(), toast.audioOption());
-                        }
-
-                        if (SUCCEEDED(hr) && toast.duration() != WinToastTemplate::Duration::System) {
-                            hr = addDurationHelper(xmlDocument.Get(),
-                                                   (toast.duration() == WinToastTemplate::Duration::Short) ? L"short"
-                                                                                                           : L"long");
-                        }
-
-                        if (SUCCEEDED(hr)) {
-                            hr = addScenarioHelper(xmlDocument.Get(), toast.scenario());
-                        }
-
-                    } else {
-                        DEBUG_MSG("Modern features (Actions/Sounds/Attributes) not supported in this os version");
-                    }
-
-                    if (SUCCEEDED(hr)) {
-                        hr = toast.hasImage() ? setImageFieldHelper(xmlDocument.Get(), toast.imagePath()) : hr;
-                        if (SUCCEEDED(hr)) {
-                            ComPtr<IToastNotification> notification;
-                            hr = notificationFactory->CreateToastNotification(xmlDocument.Get(), &notification);
-                            if (SUCCEEDED(hr)) {
-                                INT64 expiration = 0, relativeExpiration = toast.expiration();
-                                if (relativeExpiration > 0) {
-                                    InternalDateTime expirationDateTime(relativeExpiration);
-                                    expiration = expirationDateTime;
-                                    hr = notification->put_ExpirationTime(&expirationDateTime);
-                                }
-
-                                if (SUCCEEDED(hr)) {
-                                    hr = Util::setEventHandlers(notification.Get(),
-                                                                std::shared_ptr<IWinToastHandler>(handler), expiration);
-                                    if (FAILED(hr)) {
-                                        setError(error, WinToastError::InvalidHandler);
-                                    }
-                                }
-
-                                if (SUCCEEDED(hr)) {
-                                    GUID guid;
-                                    hr = CoCreateGuid(&guid);
-                                    if (SUCCEEDED(hr)) {
-                                        id = guid.Data1;
-                                        _buffer[id] = notification;
-                                        DEBUG_MSG("xml: " << Util::AsString(xmlDocument));
-                                        hr = notifier->Show(notification.Get());
-                                        if (FAILED(hr)) {
-                                            setError(error, WinToastError::NotDisplayed);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    return FAILED(hr) ? -1 : id;
-}
-
-ComPtr<IToastNotifier> WinToast::notifier(_In_ bool *succeded) const {
-    ComPtr<IToastNotificationManagerStatics> notificationManager;
-    ComPtr<IToastNotifier> notifier;
-    HRESULT hr = DllImporter::Wrap_GetActivationFactory(
-            WinToastStringWrapper(RuntimeClass_Windows_UI_Notifications_ToastNotificationManager).Get(),
-            &notificationManager);
-    if (SUCCEEDED(hr)) {
-        hr = notificationManager->CreateToastNotifierWithId(WinToastStringWrapper(_aumi).Get(), &notifier);
-    }
-    *succeded = SUCCEEDED(hr);
-    return notifier;
-}
-
-bool WinToast::hideToast(_In_ INT64 id) {
-    if (!isInitialized()) {
-        DEBUG_MSG("Error when hiding the toast. WinToast is not initialized.");
-        return false;
-    }
-
-    if (_buffer.find(id) != _buffer.end()) {
-        auto succeded = false;
-        auto notify = notifier(&succeded);
-        if (succeded) {
-            auto result = notify->Hide(_buffer[id].Get());
-            _buffer.erase(id);
-            return SUCCEEDED(result);
-        }
-    }
-    return false;
+bool WinToast::hideToast(INT64 id) {
+    return winToastImpl.hideToast(id);
 }
 
 void WinToast::clear() {
-    auto succeded = false;
-    auto notify = notifier(&succeded);
-    if (succeded) {
-        auto end = _buffer.end();
-        for (auto it = _buffer.begin(); it != end; ++it) {
-            notify->Hide(it->second.Get());
-        }
-        _buffer.clear();
-    }
+    winToastImpl.clear();
 }
 
-//
-// Available as of Windows 10 Anniversary Update
-// Ref: https://docs.microsoft.com/en-us/windows/uwp/design/shell/tiles-and-notifications/adaptive-interactive-toasts
-//
-// NOTE: This will add a new text field, so be aware when iterating over
-//       the toast's text fields or getting a count of them.
-//
-HRESULT WinToast::setAttributionTextFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &text) {
-    Util::createElement(xml, L"binding", L"text", {L"placement"});
-    ComPtr<IXmlNodeList> nodeList;
-    HRESULT hr = xml->GetElementsByTagName(WinToastStringWrapper(L"text").Get(), &nodeList);
-    if (SUCCEEDED(hr)) {
-        UINT32 nodeListLength;
-        hr = nodeList->get_Length(&nodeListLength);
-        if (SUCCEEDED(hr)) {
-            for (UINT32 i = 0; i < nodeListLength; i++) {
-                ComPtr<IXmlNode> textNode;
-                hr = nodeList->Item(i, &textNode);
-                if (SUCCEEDED(hr)) {
-                    ComPtr<IXmlNamedNodeMap> attributes;
-                    hr = textNode->get_Attributes(&attributes);
-                    if (SUCCEEDED(hr)) {
-                        ComPtr<IXmlNode> editedNode;
-                        if (SUCCEEDED(hr)) {
-                            hr = attributes->GetNamedItem(WinToastStringWrapper(L"placement").Get(), &editedNode);
-                            if (FAILED(hr) || !editedNode) {
-                                continue;
-                            }
-                            hr = Util::setNodeStringValue(L"attribution", editedNode.Get(), xml);
-                            if (SUCCEEDED(hr)) {
-                                return setTextFieldHelper(xml, text, i);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    return hr;
-}
-
-HRESULT WinToast::addDurationHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &duration) {
-    ComPtr<IXmlNodeList> nodeList;
-    HRESULT hr = xml->GetElementsByTagName(WinToastStringWrapper(L"toast").Get(), &nodeList);
-    if (SUCCEEDED(hr)) {
-        UINT32 length;
-        hr = nodeList->get_Length(&length);
-        if (SUCCEEDED(hr)) {
-            ComPtr<IXmlNode> toastNode;
-            hr = nodeList->Item(0, &toastNode);
-            if (SUCCEEDED(hr)) {
-                ComPtr<IXmlElement> toastElement;
-                hr = toastNode.As(&toastElement);
-                if (SUCCEEDED(hr)) {
-                    hr = toastElement->SetAttribute(WinToastStringWrapper(L"duration").Get(),
-                                                    WinToastStringWrapper(duration).Get());
-                }
-            }
-        }
-    }
-    return hr;
-}
-
-HRESULT WinToast::addScenarioHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &scenario) {
-    ComPtr<IXmlNodeList> nodeList;
-    HRESULT hr = xml->GetElementsByTagName(WinToastStringWrapper(L"toast").Get(), &nodeList);
-    if (SUCCEEDED(hr)) {
-        UINT32 length;
-        hr = nodeList->get_Length(&length);
-        if (SUCCEEDED(hr)) {
-            ComPtr<IXmlNode> toastNode;
-            hr = nodeList->Item(0, &toastNode);
-            if (SUCCEEDED(hr)) {
-                ComPtr<IXmlElement> toastElement;
-                hr = toastNode.As(&toastElement);
-                if (SUCCEEDED(hr)) {
-                    hr = toastElement->SetAttribute(WinToastStringWrapper(L"scenario").Get(),
-                                                    WinToastStringWrapper(scenario).Get());
-                }
-            }
-        }
-    }
-    return hr;
-}
-
-HRESULT WinToast::setTextFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &text, _In_ UINT32 pos) {
-    ComPtr<IXmlNodeList> nodeList;
-    HRESULT hr = xml->GetElementsByTagName(WinToastStringWrapper(L"text").Get(), &nodeList);
-    if (SUCCEEDED(hr)) {
-        ComPtr<IXmlNode> node;
-        hr = nodeList->Item(pos, &node);
-        if (SUCCEEDED(hr)) {
-            hr = Util::setNodeStringValue(text, node.Get(), xml);
-        }
-    }
-    return hr;
-}
-
-
-HRESULT WinToast::setImageFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &path) {
-    assert(path.size() < MAX_PATH);
-
-    wchar_t imagePath[MAX_PATH] = L"file:///";
-    HRESULT hr = StringCchCatW(imagePath, MAX_PATH, path.c_str());
-    if (SUCCEEDED(hr)) {
-        ComPtr<IXmlNodeList> nodeList;
-        hr = xml->GetElementsByTagName(WinToastStringWrapper(L"image").Get(), &nodeList);
-        if (SUCCEEDED(hr)) {
-            ComPtr<IXmlNode> node;
-            hr = nodeList->Item(0, &node);
-            if (SUCCEEDED(hr)) {
-                ComPtr<IXmlNamedNodeMap> attributes;
-                hr = node->get_Attributes(&attributes);
-                if (SUCCEEDED(hr)) {
-                    ComPtr<IXmlNode> editedNode;
-                    hr = attributes->GetNamedItem(WinToastStringWrapper(L"src").Get(), &editedNode);
-                    if (SUCCEEDED(hr)) {
-                        Util::setNodeStringValue(imagePath, editedNode.Get(), xml);
-                    }
-                }
-            }
-        }
-    }
-    return hr;
-}
-
-HRESULT WinToast::setAudioFieldHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &path, _In_opt_
-                                      WinToastTemplate::AudioOption option) {
-    std::vector<std::wstring> attrs;
-    if (!path.empty()) attrs.emplace_back(L"src");
-    if (option == WinToastTemplate::AudioOption::Loop) attrs.emplace_back(L"loop");
-    if (option == WinToastTemplate::AudioOption::Silent) attrs.emplace_back(L"silent");
-    Util::createElement(xml, L"toast", L"audio", attrs);
-
-    ComPtr<IXmlNodeList> nodeList;
-    HRESULT hr = xml->GetElementsByTagName(WinToastStringWrapper(L"audio").Get(), &nodeList);
-    if (SUCCEEDED(hr)) {
-        ComPtr<IXmlNode> node;
-        hr = nodeList->Item(0, &node);
-        if (SUCCEEDED(hr)) {
-            ComPtr<IXmlNamedNodeMap> attributes;
-            hr = node->get_Attributes(&attributes);
-            if (SUCCEEDED(hr)) {
-                ComPtr<IXmlNode> editedNode;
-                if (!path.empty()) {
-                    if (SUCCEEDED(hr)) {
-                        hr = attributes->GetNamedItem(WinToastStringWrapper(L"src").Get(), &editedNode);
-                        if (SUCCEEDED(hr)) {
-                            hr = Util::setNodeStringValue(path, editedNode.Get(), xml);
-                        }
-                    }
-                }
-
-                if (SUCCEEDED(hr)) {
-                    switch (option) {
-                        case WinToastTemplate::AudioOption::Loop:
-                            hr = attributes->GetNamedItem(WinToastStringWrapper(L"loop").Get(), &editedNode);
-                            if (SUCCEEDED(hr)) {
-                                hr = Util::setNodeStringValue(L"true", editedNode.Get(), xml);
-                            }
-                            break;
-                        case WinToastTemplate::AudioOption::Silent:
-                            hr = attributes->GetNamedItem(WinToastStringWrapper(L"silent").Get(), &editedNode);
-                            if (SUCCEEDED(hr)) {
-                                hr = Util::setNodeStringValue(L"true", editedNode.Get(), xml);
-                            }
-                        default:
-                            break;
-                    }
-                }
-            }
-        }
-    }
-    return hr;
-}
-
-HRESULT WinToast::addActionHelper(_In_ IXmlDocument *xml, _In_ const std::wstring &content, _In_
-                                  const std::wstring &arguments) {
-    ComPtr<IXmlNodeList> nodeList;
-    HRESULT hr = xml->GetElementsByTagName(WinToastStringWrapper(L"actions").Get(), &nodeList);
-    if (SUCCEEDED(hr)) {
-        UINT32 length;
-        hr = nodeList->get_Length(&length);
-        if (SUCCEEDED(hr)) {
-            ComPtr<IXmlNode> actionsNode;
-            if (length > 0) {
-                hr = nodeList->Item(0, &actionsNode);
-            } else {
-                hr = xml->GetElementsByTagName(WinToastStringWrapper(L"toast").Get(), &nodeList);
-                if (SUCCEEDED(hr)) {
-                    hr = nodeList->get_Length(&length);
-                    if (SUCCEEDED(hr)) {
-                        ComPtr<IXmlNode> toastNode;
-                        hr = nodeList->Item(0, &toastNode);
-                        if (SUCCEEDED(hr)) {
-                            ComPtr<IXmlElement> toastElement;
-                            hr = toastNode.As(&toastElement);
-                            if (SUCCEEDED(hr))
-                                hr = toastElement->SetAttribute(WinToastStringWrapper(L"template").Get(),
-                                                                WinToastStringWrapper(L"ToastGeneric").Get());
-                            if (SUCCEEDED(hr))
-                                hr = toastElement->SetAttribute(WinToastStringWrapper(L"duration").Get(),
-                                                                WinToastStringWrapper(L"long").Get());
-                            if (SUCCEEDED(hr)) {
-                                ComPtr<IXmlElement> actionsElement;
-                                hr = xml->CreateElement(WinToastStringWrapper(L"actions").Get(), &actionsElement);
-                                if (SUCCEEDED(hr)) {
-                                    hr = actionsElement.As(&actionsNode);
-                                    if (SUCCEEDED(hr)) {
-                                        ComPtr<IXmlNode> appendedChild;
-                                        hr = toastNode->AppendChild(actionsNode.Get(), &appendedChild);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            if (SUCCEEDED(hr)) {
-                ComPtr<IXmlElement> actionElement;
-                hr = xml->CreateElement(WinToastStringWrapper(L"action").Get(), &actionElement);
-                if (SUCCEEDED(hr))
-                    hr = actionElement->SetAttribute(WinToastStringWrapper(L"content").Get(),
-                                                     WinToastStringWrapper(content).Get());
-                if (SUCCEEDED(hr))
-                    hr = actionElement->SetAttribute(WinToastStringWrapper(L"arguments").Get(),
-                                                     WinToastStringWrapper(arguments).Get());
-                if (SUCCEEDED(hr)) {
-                    ComPtr<IXmlNode> actionNode;
-                    hr = actionElement.As(&actionNode);
-                    if (SUCCEEDED(hr)) {
-                        ComPtr<IXmlNode> appendedChild;
-                        hr = actionsNode->AppendChild(actionNode.Get(), &appendedChild);
-                    }
-                }
-            }
-        }
-    }
-    return hr;
-}
-
-void WinToast::setError(_Out_opt_ WinToastError *error, _In_ WinToastError value) {
-    if (error) {
-        *error = value;
-    }
-}
-
-WinToastTemplate::WinToastTemplate(_In_ WinToastTemplateType type) : _type(type) {
+WinToastTemplate::WinToastTemplate(WinToastTemplateType type) : _type(type) {
     static constexpr std::size_t TextFieldsCount[] = {1, 2, 2, 3, 1, 2, 2, 3};
     _textFields = std::vector<std::wstring>(TextFieldsCount[(int) type], L"");
 }
@@ -914,21 +120,21 @@ WinToastTemplate::~WinToastTemplate() {
     _textFields.clear();
 }
 
-void WinToastTemplate::setTextField(_In_ const std::wstring &txt, _In_ WinToastTemplate::TextField pos) {
+void WinToastTemplate::setTextField(const std::wstring &txt, WinToastTemplate::TextField pos) {
     const auto position = static_cast<std::size_t>(pos);
     assert(position < _textFields.size());
     _textFields[position] = txt;
 }
 
-void WinToastTemplate::setImagePath(_In_ const std::wstring &imgPath) {
+void WinToastTemplate::setImagePath(const std::wstring &imgPath) {
     _imagePath = imgPath;
 }
 
-void WinToastTemplate::setAudioPath(_In_ const std::wstring &audioPath) {
+void WinToastTemplate::setAudioPath(const std::wstring &audioPath) {
     _audioPath = audioPath;
 }
 
-void WinToastTemplate::setAudioPath(_In_ AudioSystemFile file) {
+void WinToastTemplate::setAudioPath(AudioSystemFile file) {
     static const std::unordered_map<AudioSystemFile, std::wstring> Files = {
             {AudioSystemFile::DefaultSound, L"ms-winsoundevent:Notification.Default"},
             {AudioSystemFile::IM,           L"ms-winsoundevent:Notification.IM"},
@@ -962,27 +168,27 @@ void WinToastTemplate::setAudioPath(_In_ AudioSystemFile file) {
     _audioPath = iter->second;
 }
 
-void WinToastTemplate::setAudioOption(_In_ WinToastTemplate::AudioOption audioOption) {
+void WinToastTemplate::setAudioOption(WinToastTemplate::AudioOption audioOption) {
     _audioOption = audioOption;
 }
 
-void WinToastTemplate::setFirstLine(_In_ const std::wstring &text) {
+void WinToastTemplate::setFirstLine(const std::wstring &text) {
     setTextField(text, WinToastTemplate::TextField::FirstLine);
 }
 
-void WinToastTemplate::setSecondLine(_In_ const std::wstring &text) {
+void WinToastTemplate::setSecondLine(const std::wstring &text) {
     setTextField(text, WinToastTemplate::TextField::SecondLine);
 }
 
-void WinToastTemplate::setThirdLine(_In_ const std::wstring &text) {
+void WinToastTemplate::setThirdLine(const std::wstring &text) {
     setTextField(text, WinToastTemplate::TextField::ThirdLine);
 }
 
-void WinToastTemplate::setDuration(_In_ Duration duration) {
+void WinToastTemplate::setDuration(Duration duration) {
     _duration = duration;
 }
 
-void WinToastTemplate::setExpiration(_In_ INT64 millisecondsFromNow) {
+void WinToastTemplate::setExpiration(INT64 millisecondsFromNow) {
     _expiration = millisecondsFromNow;
 }
 
@@ -1003,11 +209,11 @@ void WinToastLib::WinToastTemplate::setScenario(Scenario scenario) {
     }
 }
 
-void WinToastTemplate::setAttributionText(_In_ const std::wstring &attributionText) {
+void WinToastTemplate::setAttributionText(const std::wstring &attributionText) {
     _attributionText = attributionText;
 }
 
-void WinToastTemplate::addAction(_In_ const std::wstring &label) {
+void WinToastTemplate::addAction(const std::wstring &label) {
     _actions.push_back(label);
 }
 


### PR DESCRIPTION
Make the WinToast class implementation private so we can remove all the external dependencies on Windows 10 SDK in the public header. When the library will be migrated to C++/WinRT and hopefully will be able to compile with a `mingw` toolchain instead of `MSVC`, using and linking the library as a static object from a non-Windows machine without any Windows 10 SDK installed could potentially be possible.