### PR TITLE
Change WinToast to be a namespace

### DIFF
--- a/example/console-example/main.cpp
+++ b/example/console-example/main.cpp
@@ -142,22 +142,22 @@ int wmain(int argc, LPWSTR *argv) {
             return Results::UnhandledOption;
         }
 
-    WinToast::instance().setAppName(appName);
-    WinToast::instance().setAppUserModelId(appUserModelID);
+    WinToast::setAppName(appName);
+    WinToast::setAppUserModelId(appUserModelID);
 
     if (onlyCreateShortcut) {
         if (!imagePath.empty() || !text.empty() || !actions.empty() || expiration) {
             std::wcerr << L"--only-create-shortcut does not accept images/text/actions/expiration" << std::endl;
             return 9;
         }
-        WinToast::ShortcutResult result = WinToast::instance().createShortcut();
+        WinToast::ShortcutResult result = WinToast::createShortcut();
         return (int) result ? 16 + (int) result : 0;
     }
 
     if (text.empty())
         text = L"Hello, world!";
 
-    if (!WinToast::instance().initialize()) {
+    if (!WinToast::initialize()) {
         std::wcerr << L"Error, your system in not compatible!" << std::endl;
         return Results::InitializationFailure;
     }
@@ -177,7 +177,7 @@ int wmain(int argc, LPWSTR *argv) {
         templ.setImagePath(imagePath);
 
     std::unique_ptr<CustomHandler> customHandler = std::make_unique<CustomHandler>();
-    if (WinToast::instance().showToast(templ, customHandler.get()) < 0) {
+    if (WinToast::showToast(templ, customHandler.get()) < 0) {
         std::wcerr << L"Could not launch your toast notification!";
         return Results::ToastFailed;
     }

--- a/include/wintoastlib.h
+++ b/include/wintoastlib.h
@@ -29,8 +29,6 @@ typedef signed __int64 INT64, *PINT64;
 
 namespace WinToastLib {
 
-    class WinToastImpl;
-
     class IWinToastHandler {
     public:
         enum class WinToastDismissalReason {
@@ -176,8 +174,7 @@ namespace WinToastLib {
         Duration _duration{Duration::System};
     };
 
-    class WinToast {
-    public:
+    namespace WinToast {
         enum class WinToastError {
             NoError = 0,
             NotInitialized,
@@ -210,23 +207,21 @@ namespace WinToastLib {
              * This is the default. */
             SHORTCUT_POLICY_REQUIRE_CREATE = 2,
         };
-        
-        [[nodiscard]] static WinToast &instance();
 
-        [[nodiscard]] static bool isCompatible();
+        [[nodiscard]] bool isCompatible();
 
-        [[nodiscard]] static bool isSupportingModernFeatures();
+        [[nodiscard]] bool isSupportingModernFeatures();
 
-        [[nodiscard]] static std::wstring configureAUMI(const std::wstring &companyName,
+        [[nodiscard]] std::wstring configureAUMI(const std::wstring &companyName,
                                                         const std::wstring &productName,
                                                         const std::wstring &subProduct = std::wstring(),
                                                         const std::wstring &versionInformation = std::wstring());
 
-        [[nodiscard]] static const std::wstring &strerror(WinToastError error);
+        [[nodiscard]] const std::wstring &strerror(WinToastError error);
 
         bool initialize(WinToastError *error = nullptr);
 
-        [[nodiscard]] bool isInitialized() const;
+        [[nodiscard]] bool isInitialized();
 
         bool hideToast(INT64 id);
 
@@ -237,19 +232,16 @@ namespace WinToastLib {
 
         ShortcutResult createShortcut();
 
-        [[nodiscard]] const std::wstring &appName() const;
+        [[nodiscard]] const std::wstring &appName();
 
-        [[nodiscard]] const std::wstring &appUserModelId() const;
+        [[nodiscard]] const std::wstring &appUserModelId();
 
         void setAppUserModelId(const std::wstring &aumi);
 
         void setAppName(const std::wstring &appName);
 
         void setShortcutPolicy(ShortcutPolicy policy);
-
-    private:
-        static WinToastImpl &winToastImpl;
-    };
+    }
 }
 
 #endif // WINTOASTLIB_H

--- a/src/wintoastlib.cpp
+++ b/src/wintoastlib.cpp
@@ -27,88 +27,87 @@
 
 using namespace WinToastLib;
 
-WinToastImpl &WinToast::winToastImpl = WinToastImpl::instance();
+namespace WinToastLib::WinToast {
+    namespace {
+        WinToastImpl &winToastImpl = WinToastImpl::instance();
+    }
 
-WinToast &WinToast::instance() {
-    static WinToast instance;
-    return instance;
-}
+    void setAppName(const std::wstring &appName) {
+        winToastImpl.setAppName(appName);
+    }
 
-void WinToast::setAppName(const std::wstring &appName) {
-    winToastImpl.setAppName(appName);
-}
+    void setAppUserModelId(const std::wstring &aumi) {
+        winToastImpl.setAppUserModelId(aumi);
+    }
 
+    void setShortcutPolicy(ShortcutPolicy shortcutPolicy) {
+        winToastImpl.setShortcutPolicy(shortcutPolicy);
+    }
 
-void WinToast::setAppUserModelId(const std::wstring &aumi) {
-    winToastImpl.setAppUserModelId(aumi);
-}
+    bool isCompatible() {
+        return WinToastImpl::isCompatible();
+    }
 
-void WinToast::setShortcutPolicy(ShortcutPolicy shortcutPolicy) {
-    winToastImpl.setShortcutPolicy(shortcutPolicy);
-}
+    bool isSupportingModernFeatures() {
+        return WinToastImpl::isSupportingModernFeatures();
+    }
 
-bool WinToast::isCompatible() {
-    return WinToastImpl::isCompatible();
-}
+    std::wstring configureAUMI(const std::wstring &companyName,
+                               const std::wstring &productName,
+                               const std::wstring &subProduct,
+                               const std::wstring &versionInformation) {
+        return WinToastImpl::configureAUMI(companyName, productName, subProduct, versionInformation);
+    }
 
-bool WinToast::isSupportingModernFeatures() {
-    return WinToastImpl::isSupportingModernFeatures();
-}
+    const std::wstring &strerror(WinToastError error) {
+        static const std::unordered_map<WinToastError, std::wstring> Labels = {
+                {WinToastError::NoError,               L"No error. The process was executed correctly"},
+                {WinToastError::NotInitialized,        L"The library has not been initialized"},
+                {WinToastError::SystemNotSupported,    L"The OS does not support WinToast"},
+                {WinToastError::ShellLinkNotCreated,   L"The library was not able to create a Shell Link for the app"},
+                {WinToastError::InvalidAppUserModelID, L"The AUMI is not a valid one"},
+                {WinToastError::InvalidParameters,     L"The parameters used to configure the library are not valid normally because an invalid AUMI or App Name"},
+                {WinToastError::NotDisplayed,          L"The toast was created correctly but WinToast was not able to display the toast"},
+                {WinToastError::UnknownError,          L"Unknown error"}
+        };
 
-std::wstring WinToast::configureAUMI(const std::wstring &companyName,
-                                     const std::wstring &productName,
-                                     const std::wstring &subProduct,
-                                     const std::wstring &versionInformation) {
-    return WinToastImpl::configureAUMI(companyName, productName, subProduct, versionInformation);
-}
+        const auto iter = Labels.find(error);
+        assert(iter != Labels.end());
+        return iter->second;
+    }
 
-const std::wstring &WinToast::strerror(WinToastError error) {
-    static const std::unordered_map<WinToastError, std::wstring> Labels = {
-            {WinToastError::NoError,               L"No error. The process was executed correctly"},
-            {WinToastError::NotInitialized,        L"The library has not been initialized"},
-            {WinToastError::SystemNotSupported,    L"The OS does not support WinToast"},
-            {WinToastError::ShellLinkNotCreated,   L"The library was not able to create a Shell Link for the app"},
-            {WinToastError::InvalidAppUserModelID, L"The AUMI is not a valid one"},
-            {WinToastError::InvalidParameters,     L"The parameters used to configure the library are not valid normally because an invalid AUMI or App Name"},
-            {WinToastError::NotDisplayed,          L"The toast was created correctly but WinToast was not able to display the toast"},
-            {WinToastError::UnknownError,          L"Unknown error"}
-    };
+    enum ShortcutResult createShortcut() {
+        return winToastImpl.createShortcut();
+    }
 
-    const auto iter = Labels.find(error);
-    assert(iter != Labels.end());
-    return iter->second;
-}
+    bool initialize(WinToastError *error) {
+        return winToastImpl.initialize(error);
+    }
 
-enum WinToast::ShortcutResult WinToast::createShortcut() {
-    return winToastImpl.createShortcut();
-}
+    bool isInitialized() {
+        return winToastImpl.isInitialized();
+    }
 
-bool WinToast::initialize(WinToastError *error) {
-    return winToastImpl.initialize(error);
-}
+    const std::wstring &appName() {
+        return winToastImpl.appName();
+    }
 
-bool WinToast::isInitialized() const {
-    return winToastImpl.isInitialized();
-}
+    const std::wstring &appUserModelId() {
+        return winToastImpl.appUserModelId();
+    }
 
-const std::wstring &WinToast::appName() const {
-    return winToastImpl.appName();
-}
+    INT64 showToast(const WinToastTemplate &toast, IWinToastHandler *handler, WinToastError *error) {
+        return winToastImpl.showToast(toast, handler, error);
+    }
 
-const std::wstring &WinToast::appUserModelId() const {
-    return winToastImpl.appUserModelId();
-}
+    bool hideToast(INT64 id) {
+        return winToastImpl.hideToast(id);
+    }
 
-INT64 WinToast::showToast(const WinToastTemplate &toast, IWinToastHandler *handler, WinToastError *error) {
-    return winToastImpl.showToast(toast, handler, error);
-}
+    void clear() {
+        winToastImpl.clear();
+    }
 
-bool WinToast::hideToast(INT64 id) {
-    return winToastImpl.hideToast(id);
-}
-
-void WinToast::clear() {
-    winToastImpl.clear();
 }
 
 WinToastTemplate::WinToastTemplate(WinToastTemplateType type) : _type(type) {


### PR DESCRIPTION
That way, no static instance is required and we ensure that we can't create multiple instances of the class (as there is no longer a class).
We also make the private implementation really private as we don't even specify it in the header anymore.