### PR TITLE
Fix access violation error

### DIFF
--- a/src/wintoast_impl.cpp
+++ b/src/wintoast_impl.cpp
@@ -234,12 +234,6 @@ WinToastImpl::WinToastImpl() :
     }
 }
 
-WinToastImpl::~WinToastImpl() {
-    if (_hasCoInitialized) {
-        CoUninitialize();
-    }
-}
-
 void WinToastImpl::setAppName(_In_ const std::wstring &appName) {
     _appName = appName;
 }

--- a/src/wintoast_impl.h
+++ b/src/wintoast_impl.h
@@ -36,8 +36,6 @@ namespace WinToastLib {
     public:
         WinToastImpl();
 
-        ~WinToastImpl();
-
         [[nodiscard]] static WinToastImpl &instance();
 
         [[nodiscard]] static bool isCompatible();


### PR DESCRIPTION
Fix access violation in the exit code of a program using this library by not calling CoUninitialize as we use winrt::init_apartment and it's not recommended to call neither winrt::uninit_apartment nor CoUninitialize.