### PR TITLE
Refactor registration and activation with COM

### DIFF
--- a/include/wintoastlib.h
+++ b/include/wintoastlib.h
@@ -24,6 +24,9 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <functional>
+
+#define TOAST_ACTIVATED_LAUNCH_ARG "-ToastActivated"
 
 typedef signed __int64 INT64, *PINT64;
 
@@ -63,23 +66,6 @@ namespace WinToastLib {
 
     private:
         std::map<std::wstring, std::wstring> mPairs;
-    };
-
-    class IWinToastHandler {
-    public:
-        enum class WinToastDismissalReason {
-            UserCanceled,
-            ApplicationHidden,
-            TimedOut,
-        };
-
-        virtual ~IWinToastHandler() = default;
-
-        virtual void toastActivated(const WinToastArguments &arguments) const = 0;
-
-        virtual void toastDismissed(WinToastDismissalReason state) const = 0;
-
-        virtual void toastFailed() const = 0;
     };
 
     class WinToastTemplate {
@@ -247,20 +233,22 @@ namespace WinToastLib {
         [[nodiscard]] bool isSupportingModernFeatures();
 
         [[nodiscard]] std::wstring configureAUMI(const std::wstring &companyName,
-                                                        const std::wstring &productName,
-                                                        const std::wstring &subProduct = std::wstring(),
-                                                        const std::wstring &versionInformation = std::wstring());
+                                                 const std::wstring &productName,
+                                                 const std::wstring &subProduct = std::wstring(),
+                                                 const std::wstring &versionInformation = std::wstring());
 
         [[nodiscard]] const std::wstring &strerror(WinToastError error);
 
         bool initialize(WinToastError *error = nullptr);
+
+        void uninstall();
 
         [[nodiscard]] bool isInitialized();
 
         bool hideToast(INT64 id);
 
         INT64
-        showToast(const WinToastTemplate &toast, IWinToastHandler *handler, WinToastError *error = nullptr);
+        showToast(const WinToastTemplate &toast, WinToastError *error = nullptr);
 
         void clear();
 
@@ -270,11 +258,23 @@ namespace WinToastLib {
 
         [[nodiscard]] const std::wstring &appUserModelId();
 
+        [[nodiscard]] const std::wstring &iconPath();
+
+        [[nodiscard]] const std::wstring &iconBackgroundColor();
+
         void setAppUserModelId(const std::wstring &aumi);
 
         void setAppName(const std::wstring &appName);
 
+        void setIconPath(const std::wstring &iconPath);
+
+        void setIconBackgroundColor(const std::wstring &iconBackgroundColor);
+
         void setShortcutPolicy(ShortcutPolicy policy);
+
+        void setOnActivated(
+                const std::function<void(const WinToastArguments &,
+                                         const std::map<std::wstring, std::wstring> &)> &callback);
     }
 }
 

--- a/src/wintoast_impl.h
+++ b/src/wintoast_impl.h
@@ -27,6 +27,7 @@
 #include <winrt/Windows.UI.Notifications.h>
 
 #include <map>
+#include <functional>
 
 #include "wintoastlib.h"
 
@@ -43,18 +44,19 @@ namespace WinToastLib {
         [[nodiscard]] static bool isSupportingModernFeatures();
 
         [[nodiscard]] static std::wstring configureAUMI(_In_ const std::wstring &companyName,
-                                          _In_ const std::wstring &productName,
-                                          _In_ const std::wstring &subProduct = std::wstring(),
-                                          _In_ const std::wstring &versionInformation = std::wstring());
+                                                        _In_ const std::wstring &productName,
+                                                        _In_ const std::wstring &subProduct = std::wstring(),
+                                                        _In_ const std::wstring &versionInformation = std::wstring());
 
         bool initialize(_Out_opt_ WinToast::WinToastError *error = nullptr);
+
+        void uninstall();
 
         [[nodiscard]] bool isInitialized() const;
 
         bool hideToast(_In_ INT64 id);
 
-        INT64 showToast(_In_ const WinToastTemplate &toast, _In_ IWinToastHandler *handler, _Out_opt_
-                                WinToast::WinToastError *error = nullptr);
+        INT64 showToast(_In_ const WinToastTemplate &toast, _Out_opt_ WinToast::WinToastError *error = nullptr);
 
         void clear();
 
@@ -64,11 +66,23 @@ namespace WinToastLib {
 
         [[nodiscard]] const std::wstring &appUserModelId() const;
 
+        [[nodiscard]] const std::wstring &iconPath() const;
+
+        [[nodiscard]] const std::wstring &iconBackgroundColor() const;
+
         void setAppUserModelId(_In_ const std::wstring &aumi);
 
         void setAppName(_In_ const std::wstring &appName);
 
+        void setIconPath(_In_ const std::wstring &iconPath);
+
+        void setIconBackgroundColor(_In_ const std::wstring &iconBackgroundColor);
+
         void setShortcutPolicy(_In_ WinToast::ShortcutPolicy policy);
+
+        void setOnActivated(
+                const std::function<void(const WinToastArguments &,
+                                         const std::map<std::wstring, std::wstring> &)> &callback);
 
     private:
         bool _isInitialized{false};
@@ -76,7 +90,12 @@ namespace WinToastLib {
         WinToast::ShortcutPolicy _shortcutPolicy{WinToast::ShortcutPolicy::SHORTCUT_POLICY_REQUIRE_CREATE};
         std::wstring _appName{};
         std::wstring _aumi{};
+        std::wstring _clsid{};
+        std::wstring _iconPath{};
+        std::wstring _iconBackgroundColor{};
         std::map<INT64, winrt::Windows::UI::Notifications::ToastNotification> _buffer{};
+
+        void createAndRegisterActivator();
 
         void validateShellLinkHelper(_Out_ bool &wasChanged);
 

--- a/src/wintoastlib.cpp
+++ b/src/wintoastlib.cpp
@@ -40,8 +40,22 @@ namespace WinToastLib::WinToast {
         winToastImpl.setAppUserModelId(aumi);
     }
 
+    void setIconPath(const std::wstring &iconPath) {
+        winToastImpl.setIconPath(iconPath);
+    }
+
+    void setIconBackgroundColor(const std::wstring &iconBackgroundColor) {
+        winToastImpl.setIconBackgroundColor(iconBackgroundColor);
+    }
+
     void setShortcutPolicy(ShortcutPolicy shortcutPolicy) {
         winToastImpl.setShortcutPolicy(shortcutPolicy);
+    }
+
+    void setOnActivated(
+            const std::function<void(const WinToastArguments &,
+                                     const std::map<std::wstring, std::wstring> &)> &callback) {
+        winToastImpl.setOnActivated(callback);
     }
 
     bool isCompatible() {
@@ -85,6 +99,10 @@ namespace WinToastLib::WinToast {
         return winToastImpl.initialize(error);
     }
 
+    void uninstall() {
+        winToastImpl.uninstall();
+    }
+
     bool isInitialized() {
         return winToastImpl.isInitialized();
     }
@@ -97,8 +115,16 @@ namespace WinToastLib::WinToast {
         return winToastImpl.appUserModelId();
     }
 
-    INT64 showToast(const WinToastTemplate &toast, IWinToastHandler *handler, WinToastError *error) {
-        return winToastImpl.showToast(toast, handler, error);
+    const std::wstring &iconPath() {
+        return winToastImpl.iconPath();
+    }
+
+    const std::wstring &iconBackgroundColor() {
+        return winToastImpl.iconBackgroundColor();
+    }
+
+    INT64 showToast(const WinToastTemplate &toast, WinToastError *error) {
+        return winToastImpl.showToast(toast, error);
     }
 
     bool hideToast(INT64 id) {


### PR DESCRIPTION
Refactor registration and activation with COM and provide one method for setting the activation callback instead of handling each toast separately. To distinguish between toasts the user can add unique arguments for each toast but support for that isn't implemented yet.

With the refactoring comes also the ability to set the icon path and background color in the notification itself and the windows settings page for the associated app so methods for that were added.

One more benefit from this refactoring is the ability for the app to be activated even if it's closed. The app will be launched with a "-ToastActivated" argument which the app can use for quickly setting the activation callback and then initialize the library.